### PR TITLE
[CSL-354] Server side tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Constructor-io/constructorio-node#readme",
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=14.5.0"
   },
   "pre-push": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Constructor-io/constructorio-node#readme",
   "engines": {
-    "node": ">=14.5.0"
+    "node": ">=8.3.0"
   },
   "pre-push": [
     "lint"

--- a/spec/mocha.helpers.js
+++ b/spec/mocha.helpers.js
@@ -31,7 +31,7 @@ const extractBodyParamsFromFetch = (fetch) => {
 const extractHeadersFromFetch = (fetch) => {
   const lastCallArguments = fetch && fetch.args && fetch.args[fetch.args.length - 1];
   const requestData = lastCallArguments[1];
-  const { headers } = requestData;
+  const { headers } = requestData || {};
 
   if (headers) {
     return headers;

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1,0 +1,3607 @@
+/* eslint-disable no-unused-expressions, import/no-unresolved */
+const jsdom = require('mocha-jsdom');
+const dotenv = require('dotenv');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const nodeFetch = require('node-fetch');
+const cloneDeep = require('lodash.clonedeep');
+const ConstructorIO = require('../../../test/constructorio');
+const helpers = require('../../mocha.helpers');
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+dotenv.config();
+
+const delayBetweenTests = 25;
+const testApiKey = process.env.TEST_API_KEY;
+
+describe.only('ConstructorIO - Tracker', () => {
+  const clientVersion = 'cio-mocha';
+  let fetchSpy = null;
+  const userParameters = {
+    i: '6c73138f-c27b-49f0-872d-63b00ed0e395',
+    s: 1,
+  };
+
+  jsdom({ url: 'http://localhost' });
+
+  beforeEach(() => {
+    fetchSpy = sinon.spy(nodeFetch);
+    global.CLIENT_VERSION = clientVersion;
+  });
+
+  afterEach((done) => {
+    fetchSpy = null;
+
+    delete global.CLIENT_VERSION;
+    setTimeout(done, delayBetweenTests);
+  });
+
+  describe.only('trackSessionStart', () => {
+    it('Should respond with a valid response', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('action').to.equal('session_start');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+
+    it('Should respond with a valid response with segments', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+
+    it('Should respond with a valid response with userId', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is not defined', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+
+    it('Should respond with a valid response with testCells', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+
+    it('Should respond with a valid response with multiple testCells', (done) => {
+      const testCells = {
+        foo: 'bar',
+        bar: 'foo',
+        far: 'boo',
+      };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[1]}`).to.equal(Object.values(testCells)[1]);
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[2]}`).to.equal(Object.values(testCells)[2]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart()).to.equal(true);
+    });
+  });
+
+  describe('trackInputFocus', () => {
+    it('Should respond with a valid response', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('action').to.equal('focus');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus()).to.equal(true);
+    });
+
+    it('Should respond with a valid response with segments', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus()).to.equal(true);
+    });
+
+    it('Should respond with a valid response with userId', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus()).to.equal(true);
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus()).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).not.to.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus()).to.equal(true);
+    });
+
+    it('Should respond with a valid response with testCells', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus()).to.equal(true);
+    });
+  });
+
+  describe('trackAutocompleteSelect', () => {
+    const term = 'Where The Wild Things Are';
+    const requiredParameters = {
+      original_query: 'original-query',
+      result_id: 'result-id',
+      section: 'Search Suggestions',
+    };
+    const optionalParameters = {
+      tr: 'click',
+      group_id: 'group-id',
+      display_name: 'display-name',
+    };
+
+    it('Should respond with a valid response when term and required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
+        expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('tr').to.equal(optionalParameters.tr);
+        expect(requestParams).to.have.property('group').to.deep.equal({
+          group_id: optionalParameters.group_id,
+          display_name: optionalParameters.display_name,
+        });
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, Object.assign(requiredParameters, optionalParameters)))
+        .to.equal(true);
+    });
+
+    it('Should throw an error when invalid term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackAutocompleteSelect([], requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when no term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackAutocompleteSelect(null, requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackAutocompleteSelect(term, [])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackAutocompleteSelect(term)).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackSearchSubmit', () => {
+    const term = 'Where The Wild Things Are';
+    const requiredParameters = {
+      original_query: 'original-query',
+      result_id: 'result-id',
+    };
+    const optionalParameters = {
+      group_id: 'group-id',
+      display_name: 'display-name',
+    };
+
+    it('Should respond with a valid response when term and required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
+        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('group').to.deep.equal({
+          group_id: optionalParameters.group_id,
+          display_name: optionalParameters.display_name,
+        });
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should throw an error when invalid term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchSubmit([], requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when no term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchSubmit(null, requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchSubmit(term, [])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchSubmit(term)).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackSearchResultsLoaded', () => {
+    const term = 'Cat in the Hat';
+    const requiredParameters = {
+      num_results: 1337,
+    };
+    const optionalParameters = {
+      customer_ids: [1, 2, 3],
+    };
+
+    it('Should respond with a valid response when term and required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('num_results').to.equal(requiredParameters.num_results.toString());
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('customer_ids').to.equal(optionalParameters.customer_ids.join(','));
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, Object.assign(requiredParameters, optionalParameters)))
+        .to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, and zero value num_results parameter are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('num_results').to.equal('0');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, { num_results: 0 })).to.equal(true);
+    });
+
+    it('Should throw an error when invalid term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultsLoaded([], requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when no term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultsLoaded(null, requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultsLoaded(term, [])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultsLoaded(term)).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackSearchResultClick', () => {
+    const term = 'Where The Wild Things Are';
+    const requiredParameters = {
+      name: 'name',
+      customer_id: 'customer-id',
+      result_id: 'result-id',
+    };
+
+    it('Should respond with a valid response when term and required parmeters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('name').to.equal(requiredParameters.name);
+        expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.customer_id);
+        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and variation id is provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('variation_id').to.equal('variation-id');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, {
+        ...requiredParameters,
+        variation_id: 'variation-id',
+      })).to.equal(true);
+    });
+
+    it('Should throw an error when invalid term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultClick([], requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when no term is provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultClick(null, requiredParameters)).to.be.an('error');
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultClick(term, [])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultClick(term)).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackConversion', () => {
+    const term = 'Where The Wild Things Are';
+    const requiredParameters = {
+      item_id: 'customer-id',
+      revenue: 123,
+      section: 'Products',
+    };
+
+    const optionalParameters = {
+      item_name: 'item_name',
+      variation_id: 'variation-id',
+    };
+
+    it('Should respond with a valid response when term and required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(queryParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+        expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
+        expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters, and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(queryParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+        expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
+        expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(requestParams).to.have.property('item_name').to.equal(optionalParameters.item_name);
+        expect(requestParams).to.have.property('variation_id').to.equal(optionalParameters.variation_id);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, Object.assign({}, requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when term and required parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(requiredParameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal('Products');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackConversion(term, clonedParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and conversion type are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        type: 'add_to_wishlist',
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('type').to.equal(fullParameters.type);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and custom conversion type are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        type: 'add_to_loves',
+        display_name: 'Add To Loves List',
+        is_custom_type: true,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('type').to.equal(fullParameters.type);
+        expect(requestParams).to.have.property('is_custom_type').to.equal(fullParameters.is_custom_type);
+        expect(requestParams).to.have.property('display_name').to.equal(fullParameters.display_name);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when no term is provided, but parameters are', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackConversion(null, requiredParameters)).to.equal(true);
+    });
+
+    it('should respond with a valid response if is_custom_type is true, display_name is provided, and no type is specified', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        display_name: 'Add To Loves List',
+        is_custom_type: true,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('display_name').to.equal(fullParameters.display_name);
+        expect(requestParams).to.have.property('is_custom_type').to.equal(fullParameters.is_custom_type);
+        expect(requestParams).to.not.have.property('type');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+    });
+
+    it('should respond with an error if is_custom_type is true, type is provided, and no display_name is specified', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        type: 'add_to_loves',
+        is_custom_type: true,
+      });
+
+      tracker.on('error', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('type').to.equal(fullParameters.type);
+        expect(requestParams).to.have.property('is_custom_type').to.equal(fullParameters.is_custom_type);
+        expect(requestParams).to.not.have.property('display_name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('Conversion type must be one of add_to_wishlist, add_to_cart, like, message, make_offer, read. If you wish to use custom conversion types, please set is_custom_type to true and specify a display_name.');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+    });
+
+    it('should support v1 endpoint arguments', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      const parameters = {
+        customer_id: 'customer-id',
+        name: 'name',
+        section: 'Products',
+        revenue: 123,
+      };
+
+      tracker.on('success', (responseParams) => {
+        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(queryParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('item_id').to.equal(parameters.customer_id);
+        expect(requestParams).to.have.property('item_name').to.equal(parameters.name);
+        expect(requestParams).to.have.property('revenue').to.equal(parameters.revenue.toString());
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, parameters)).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultClick(term, [])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackSearchResultClick(term)).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackPurchase', () => {
+    const requiredParameters = {
+      items: [
+        {
+          item_id: 'productc60366c42b5d4194ad39962fd88d7266',
+          variation_id: '456',
+        },
+        {
+          item_id: 'product55f1b3577fa84947a93ea01b91d52f45',
+        },
+      ],
+      revenue: 123.45,
+    };
+    const optionalParameters = {
+      order_id: '123938123',
+      section: 'Products',
+    };
+
+    it('Should respond with a valid response when required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        expect(requestParams).to.have.property('items').to.deep.equal(requiredParameters.items);
+        expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestQueryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestQueryParams).to.have.property('section').to.equal(optionalParameters.section);
+        expect(requestBodyParams).to.have.property('order_id').to.equal(optionalParameters.order_id);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal('Products');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters)).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackPurchase([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackPurchase()).to.be.an('error');
+    });
+
+    it('Should respond with a success if beacon=true and a non-existent item_id is provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('beacon').to.equal(true);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase({
+        ...requiredParameters,
+        items: [
+          {
+            item_id: 'bad-item-id-10',
+            variation_id: '456',
+          },
+          {
+            item_id: 'bad-item-id-11',
+          },
+        ],
+      })).to.equal(true);
+    });
+
+    it('Should respond with an error if beacon=true is not in the request and a non-existent item_id is provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+        beaconMode: false,
+      });
+
+      tracker.on('error', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('beacon');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.contain('There is no item with item_id="bad-item-id-10".');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase({
+        ...requiredParameters,
+        items: [
+          {
+            item_id: 'bad-item-id-10',
+          },
+        ],
+      })).to.equal(true);
+    });
+
+    it('Should respond with an error if beacon=true is not in the request and a non-existent item_id/variation_id is provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+        beaconMode: false,
+      });
+
+      tracker.on('error', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('beacon');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.contain('There is no variation item with variation_id="456".');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase({
+        ...requiredParameters,
+        items: [
+          {
+            item_id: 'bad-item-id-10',
+            variation_id: '456',
+          },
+        ],
+      })).to.equal(true);
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters)).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackPurchase([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackPurchase()).to.be.an('error');
+    });
+  });
+
+  describe('trackRecommendationView', () => {
+    const requiredParameters = {
+      pod_id: 'test_pod_id',
+      num_results_viewed: 5,
+      url: 'https://constructor.io',
+    };
+    const optionalParameters = {
+      result_count: 5,
+      result_page: 1,
+      result_id: 'result-id',
+      section: 'Products',
+    };
+
+    it('Should respond with a valid response when required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
+        expect(requestParams).to.have.property('pod_id').to.equal(requiredParameters.pod_id);
+        expect(requestParams).to.have.property('num_results_viewed').to.equal(requiredParameters.num_results_viewed);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(requiredParameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal('Products');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackRecommendationView(clonedParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('result_count').to.equal(optionalParameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(optionalParameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(optionalParameters.result_id);
+        expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationView([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationView()).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackRecommendationClick', () => {
+    // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog
+    const requiredParameters = {
+      pod_id: 'test_pod_id',
+      strategy_id: 'strategy-id',
+      item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
+    };
+    const optionalParameters = {
+      result_position_on_page: 10,
+      num_results_per_page: 5,
+      result_count: 5,
+      result_page: 1,
+      result_id: 'result-id',
+      section: 'Products',
+    };
+
+    it('Should respond with a valid response when required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('pod_id').to.equal(requiredParameters.pod_id);
+        expect(requestParams).to.have.property('strategy_id').to.equal(requiredParameters.strategy_id);
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(requiredParameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal('Products');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackRecommendationClick(clonedParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('result_position_on_page').to.equal(optionalParameters.result_position_on_page);
+        expect(requestParams).to.have.property('num_results_per_page').to.equal(optionalParameters.num_results_per_page);
+        expect(requestParams).to.have.property('result_count').to.equal(optionalParameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(optionalParameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(optionalParameters.result_id);
+        expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should respond with a success if beacon=true and a non-existent item_id is provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+      const parameters = {
+        ...requiredParameters,
+        ...optionalParameters,
+        item_id: 'non-existent-item-id',
+      };
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
+        expect(requestParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
+        expect(requestParams).to.have.property('result_count').to.equal(parameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(parameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(parameters.result_id);
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(parameters)).to.equal(true);
+    });
+
+    it('Should respond with an error if beacon=true is not in the request and a non-existent item_id is provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+        beaconMode: false,
+      });
+      const parameters = {
+        ...requiredParameters,
+        ...optionalParameters,
+        item_id: 'non-existent-item-id',
+      };
+
+      tracker.on('error', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
+        expect(requestParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
+        expect(requestParams).to.have.property('result_count').to.equal(parameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(parameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(parameters.result_id);
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.contain('There is no item with item_id="non-existent-item-id"');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(parameters)).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationClick([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationClick()).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackBrowseResultsLoaded', () => {
+    const requiredParameters = {
+      sort_by: 'price',
+      sort_order: 'ascending',
+      filter_name: 'group_id',
+      filter_value: 'Clothing',
+      url: 'http://constructor.io',
+    };
+    const optionalParameters = {
+      section: 'Products',
+      result_count: 5,
+      result_page: 1,
+      result_id: 'result-id',
+      selected_filters: { foo: ['bar'] },
+      items: [
+        {
+          item_id: '123',
+          variation_id: '456',
+        },
+        {
+          item_id: '789',
+        },
+      ],
+    };
+
+    it('Should respond with a valid response when required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('sort_by').to.equal(requiredParameters.sort_by);
+        expect(requestParams).to.have.property('sort_order').to.equal(requiredParameters.sort_order);
+        expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
+        expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
+        expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(requiredParameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal('Products');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackBrowseResultsLoaded(clonedParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
+        expect(requestParams).to.have.property('result_count').to.equal(optionalParameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(optionalParameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(optionalParameters.result_id);
+        expect(requestParams).to.have.property('selected_filters').to.deep.equal(optionalParameters.selected_filters);
+        expect(requestParams).to.have.property('items').to.deep.equal(optionalParameters.items);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultsLoaded([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultsLoaded()).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('trackBrowseResultClick', () => {
+    // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog
+    const requiredParameters = {
+      item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
+      filter_name: 'group_id',
+      filter_value: 'Clothing',
+    };
+    const optionalParameters = {
+      section: 'Products',
+      result_count: 5,
+      result_page: 1,
+      result_id: 'result-id',
+      result_position_on_page: 10,
+      num_results_per_page: 5,
+      selected_filters: { foo: ['bar'] },
+    };
+
+    it('Should respond with a valid response when required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+        expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
+        expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(requiredParameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal('Products');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackBrowseResultClick(clonedParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
+        expect(requestParams).to.have.property('result_count').to.equal(optionalParameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(optionalParameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(optionalParameters.result_id);
+        expect(requestParams).to.have.property('result_position_on_page').to.equal(optionalParameters.result_position_on_page);
+        expect(requestParams).to.have.property('num_results_per_page').to.equal(optionalParameters.num_results_per_page);
+        expect(requestParams).to.have.property('selected_filters').to.deep.equal(optionalParameters.selected_filters);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+      const parameters = {
+        ...requiredParameters,
+        ...optionalParameters,
+        item_id: 'non-existent-item-id',
+      };
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('result_count').to.equal(parameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(parameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(parameters.result_id);
+        expect(requestParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
+        expect(requestParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
+        expect(requestParams).to.have.property('selected_filters').to.deep.equal(parameters.selected_filters);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+        beaconMode: false,
+      });
+      const parameters = {
+        ...requiredParameters,
+        ...optionalParameters,
+        item_id: 'non-existent-item-id',
+      };
+
+      tracker.on('error', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('result_count').to.equal(parameters.result_count);
+        expect(requestParams).to.have.property('result_page').to.equal(parameters.result_page);
+        expect(requestParams).to.have.property('result_id').to.equal(parameters.result_id);
+        expect(requestParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
+        expect(requestParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
+        expect(requestParams).to.have.property('selected_filters').to.deep.equal(parameters.selected_filters);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.contain('There is no item with item_id="non-existent-item-id"');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultClick([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultClick()).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+    });
+  });
+
+
+  describe('trackGenericResultClick', () => {
+    // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog
+    const requiredParameters = {
+      item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
+    };
+    const optionalParameters = {
+      item_name: 'Example Product Name',
+      section: 'Products',
+    };
+
+    it('Should respond with a valid response when required parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(requiredParameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal('Products');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackGenericResultClick(clonedParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        testCells,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams)
+          .to.have.property(`ef-${Object.keys(testCells)[0]}`)
+          .to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+        expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.item_name);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+      const parameters = {
+        ...requiredParameters,
+        ...optionalParameters,
+        item_id: 'non-existent-item-id',
+      };
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('item_id').to.equal(parameters.item_id);
+        expect(requestParams).to.have.property('item_name').to.deep.equal(parameters.item_name);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(parameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+        beaconMode: false,
+      });
+      const parameters = {
+        ...requiredParameters,
+        ...optionalParameters,
+        item_id: 'non-existent-item-id',
+      };
+
+      tracker.on('error', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('item_id').to.equal(parameters.item_id);
+        expect(requestParams).to.have.property('item_name').to.equal(parameters.item_name);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams)
+          .to.have.property('message')
+          .to.contain('There is no item with item_id="non-existent-item-id"');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(parameters)).to.equal(true);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackGenericResultClick([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackGenericResultClick()).to.be.an('error');
+    });
+
+    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: true,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        sendReferrerWithTrackingEvents: false,
+        ...userParameters,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('origin_referrer');
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+    });
+  });
+
+  describe('on', () => {
+    it('Should throw an error when providing an invalid messageType parameter', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.on('invalid')).to.be.an('error');
+    });
+
+    it('Should throw an error when providing no messageType parameter', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.on(null, () => {})).to.be.an('error');
+    });
+
+    it('Should throw an error when providing an invalid callback parameter', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.on('success', {})).to.be.an('error');
+    });
+
+    it('Should throw an error when providing no callback parameter', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.on('success', null)).to.be.an('error');
+    });
+
+    it('Should receive a success message when making a request to a valid endpoint', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.trackSessionStart();
+
+      tracker.on('success', (response) => {
+        expect(response).to.have.property('url');
+        expect(response).to.have.property('method');
+        expect(response).to.have.property('message').to.equal('ok');
+        done();
+      });
+    });
+
+    it('Should receive an error message when making a request to an endpoint that does not return valid JSON', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        serviceUrl: 'http://constructor.io',
+        ...userParameters,
+      });
+
+      tracker.trackSessionStart();
+
+      tracker.on('error', (response) => {
+        expect(response).to.have.property('url');
+        expect(response).to.have.property('method');
+        expect(response).to.have.property('message');
+        done();
+      });
+    });
+
+    it('Should receive an error message when making a request to an invalid endpoint', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        serviceUrl: 'invalid',
+        ...userParameters,
+      });
+
+      tracker.trackSessionStart();
+
+      tracker.on('error', (response) => {
+        expect(response).to.have.property('url');
+        expect(response).to.have.property('method');
+        expect(response).to.have.property('message');
+        done();
+      });
+    });
+  });
+});

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1688,7 +1688,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackConversion', () => {
+  describe('trackConversion', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       item_id: 'labradoodle',
@@ -2465,7 +2465,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackRecommendationView', () => {
+  describe.only('trackRecommendationView', () => {
     const requiredParameters = {
       pod_id: 'test_pod_id',
       num_results_viewed: 5,
@@ -2482,7 +2482,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2498,7 +2497,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
         expect(requestParams).to.have.property('pod_id').to.equal(requiredParameters.pod_id);
         expect(requestParams).to.have.property('num_results_viewed').to.equal(requiredParameters.num_results_viewed);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -2507,7 +2505,7 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+      expect(tracker.trackRecommendationView(requiredParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
@@ -2515,7 +2513,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2534,92 +2531,13 @@ describe.only('ConstructorIO - Tracker', () => {
 
       delete clonedParameters.section;
 
-      expect(tracker.trackRecommendationView(clonedParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        segments,
-        fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
-      const testCells = { foo: 'bar' };
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        testCells,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('ui').to.equal(userId);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+      expect(tracker.trackRecommendationView(clonedParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response when required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2639,69 +2557,209 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackRecommendationView(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+      expect(tracker.trackRecommendationView(
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
+    });
+
+    it('Should respond with a valid response when parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and test cells are provided', (done) => {
+      const testCells = { foo: 'bar' };
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackRecommendationView([])).to.be.an('error');
+      expect(tracker.trackRecommendationView([], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackRecommendationView()).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
+      expect(tracker.trackRecommendationView(null, userParameters)).to.be.an('error');
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -17,9 +17,6 @@ dotenv.config();
 const delayBetweenTests = 25;
 const testApiKey = process.env.TEST_API_KEY;
 
-// TODO:
-// - Should we enforce that tracker always has i & s parameters
-// - Is beacon mode relevant in this implementation? if so, need to restore some methods for trackPurchase
 describe.only('ConstructorIO - Tracker', () => {
   const clientVersion = 'cio-mocha';
   let fetchSpy = null;
@@ -291,6 +288,60 @@ describe.only('ConstructorIO - Tracker', () => {
         userAgent,
       })).to.equal(true);
     });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart({
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart({
+        ...userParameters,
+        referer,
+      })).to.equal(true);
+    });
   });
 
   describe('trackInputFocus', () => {
@@ -542,6 +593,60 @@ describe.only('ConstructorIO - Tracker', () => {
         userAgent,
       })).to.equal(true);
     });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus({
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackInputFocus({
+        ...userParameters,
+        referer,
+      })).to.equal(true);
+    });
   });
 
   describe('trackAutocompleteSelect', () => {
@@ -773,6 +878,60 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
         userAgent,
         ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
+        ...userParameters,
+        referer,
       })).to.equal(true);
     });
 
@@ -1060,6 +1219,60 @@ describe.only('ConstructorIO - Tracker', () => {
       })).to.equal(true);
     });
 
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        ...userParameters,
+        referer,
+      })).to.equal(true);
+    });
+
     it('Should respond with a valid response when term, required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -1337,6 +1550,60 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
         userAgent,
         ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        ...userParameters,
+        referer,
       })).to.equal(true);
     });
 
@@ -1640,6 +1907,60 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchResultClick(term, requiredParameters, {
         userAgent,
         ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        ...userParameters,
+        referer,
       })).to.equal(true);
     });
 
@@ -1988,6 +2309,60 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters, {
         userAgent,
         ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters, {
+        ...userParameters,
+        referer,
       })).to.equal(true);
     });
 
@@ -2450,6 +2825,60 @@ describe.only('ConstructorIO - Tracker', () => {
       })).to.equal(true);
     });
 
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackPurchase(requiredParameters, {
+        ...userParameters,
+        referer,
+      })).to.equal(true);
+    });
+
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -2761,6 +3190,60 @@ describe.only('ConstructorIO - Tracker', () => {
       })).to.equal(true);
     });
 
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationView(requiredParameters, {
+        ...userParameters,
+        referer,
+      })).to.equal(true);
+    });
+
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -3031,6 +3514,60 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackRecommendationClick(requiredParameters, {
         userAgent,
         ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        ...userParameters,
+        referer,
       })).to.equal(true);
     });
 
@@ -3349,6 +3886,60 @@ describe.only('ConstructorIO - Tracker', () => {
       })).to.equal(true);
     });
 
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        ...userParameters,
+        referer,
+      })).to.equal(true);
+    });
+
     it('Should respond with a valid response when required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -3652,6 +4243,60 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackBrowseResultClick(requiredParameters, {
         userAgent,
         ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        ...userParameters,
+        referer,
       })).to.equal(true);
     });
 
@@ -3985,6 +4630,60 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackGenericResultClick(requiredParameters, {
         userAgent,
         ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with accept language', (done) => {
+      const acceptLanguage = 'en-US';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Accept-Language').to.equal(acceptLanguage);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        ...userParameters,
+        acceptLanguage,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with referer', (done) => {
+      const referer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('Referer').to.equal(referer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        ...userParameters,
+        referer,
       })).to.equal(true);
     });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -17,7 +17,7 @@ dotenv.config();
 const delayBetweenTests = 25;
 const testApiKey = process.env.TEST_API_KEY;
 
-describe.only('ConstructorIO - Tracker', () => {
+describe('ConstructorIO - Tracker', () => {
   const clientVersion = 'cio-mocha';
   let fetchSpy = null;
   const userParameters = {

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -541,7 +541,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackAutocompleteSelect', () => {
+  describe('trackAutocompleteSelect', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       original_query: 'original-query',
@@ -1110,7 +1110,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackSearchResultsLoaded', () => {
+  describe.only('trackSearchResultsLoaded', () => {
     const term = 'Cat in the Hat';
     const requiredParameters = {
       num_results: 1337,
@@ -1123,7 +1123,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1137,7 +1136,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('num_results').to.equal(requiredParameters.num_results.toString());
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1146,42 +1144,14 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
+    it('Should respond with a valid response when term, required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1198,16 +1168,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1224,14 +1222,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1245,12 +1351,14 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(responseParams).to.have.property('method').to.equal('GET');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
-
         done();
       });
 
-      expect(tracker.trackSearchResultsLoaded(term, Object.assign(requiredParameters, optionalParameters)))
-        .to.equal(true);
+      expect(tracker.trackSearchResultsLoaded(
+        term,
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should respond with a valid response when term, and zero value num_results parameter are provided', (done) => {
@@ -1275,81 +1383,31 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultsLoaded(term, { num_results: 0 })).to.equal(true);
+      expect(tracker.trackSearchResultsLoaded(term, { num_results: 0 }, userParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultsLoaded([], requiredParameters)).to.be.an('error');
+      expect(tracker.trackSearchResultsLoaded([], requiredParameters, userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultsLoaded(null, requiredParameters)).to.be.an('error');
+      expect(tracker.trackSearchResultsLoaded(null, requiredParameters, userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultsLoaded(term, [])).to.be.an('error');
+      expect(tracker.trackSearchResultsLoaded(term, [], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultsLoaded(term)).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultsLoaded(term, null, userParameters)).to.be.an('error');
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -60,6 +60,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('action').to.equal('session_start');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -310,6 +311,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('action').to.equal('focus');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -571,6 +573,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
@@ -856,6 +859,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
         expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
 
@@ -1136,6 +1140,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('num_results').to.equal(requiredParameters.num_results.toString());
 
         // Response
@@ -1436,6 +1441,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('name').to.equal(requiredParameters.name);
         expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.customer_id);
         expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
@@ -1718,6 +1724,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
@@ -1750,6 +1757,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
@@ -2098,6 +2106,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('item_id').to.equal(parameters.customer_id);
         expect(requestParams).to.have.property('item_name').to.equal(parameters.name);
         expect(requestParams).to.have.property('revenue').to.equal(parameters.revenue.toString());
@@ -2155,7 +2164,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackPurchase', () => {
+  describe('trackPurchase', () => {
     const requiredParameters = {
       items: [
         {
@@ -2189,6 +2198,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('items').to.deep.equal(requiredParameters.items);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue);
 
@@ -2494,6 +2504,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
         expect(requestParams).to.have.property('pod_id').to.equal(requiredParameters.pod_id);
         expect(requestParams).to.have.property('num_results_viewed').to.equal(requiredParameters.num_results_viewed);
@@ -2763,7 +2774,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackRecommendationClick', () => {
+  describe.only('trackRecommendationClick', () => {
     // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog
     const requiredParameters = {
       pod_id: 'test_pod_id',
@@ -2783,7 +2794,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2796,10 +2806,10 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('pod_id').to.equal(requiredParameters.pod_id);
         expect(requestParams).to.have.property('strategy_id').to.equal(requiredParameters.strategy_id);
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -2808,7 +2818,7 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackRecommendationClick(requiredParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
@@ -2816,7 +2826,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2835,42 +2844,14 @@ describe.only('ConstructorIO - Tracker', () => {
 
       delete clonedParameters.section;
 
-      expect(tracker.trackRecommendationClick(clonedParameters)).to.equal(true);
+      expect(tracker.trackRecommendationClick(clonedParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        segments,
-        fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
+    it('Should respond with a valid response when required parameters and user identifier are provided', (done) => {
       const userId = 'user-id';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        userId,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2887,16 +2868,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2913,14 +2922,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -2942,138 +3059,22 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackRecommendationClick(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
-    });
-
-    it('Should respond with a success if beacon=true and a non-existent item_id is provided', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        ...userParameters,
-      });
-      const parameters = {
-        ...requiredParameters,
-        ...optionalParameters,
-        item_id: 'non-existent-item-id',
-      };
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
-        expect(requestParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
-        expect(requestParams).to.have.property('result_count').to.equal(parameters.result_count);
-        expect(requestParams).to.have.property('result_page').to.equal(parameters.result_page);
-        expect(requestParams).to.have.property('result_id').to.equal(parameters.result_id);
-        expect(requestParams).to.have.property('section').to.equal(parameters.section);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationClick(parameters)).to.equal(true);
-    });
-
-    it('Should respond with an error if beacon=true is not in the request and a non-existent item_id is provided', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        ...userParameters,
-        beaconMode: false,
-      });
-      const parameters = {
-        ...requiredParameters,
-        ...optionalParameters,
-        item_id: 'non-existent-item-id',
-      };
-
-      tracker.on('error', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
-        expect(requestParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
-        expect(requestParams).to.have.property('result_count').to.equal(parameters.result_count);
-        expect(requestParams).to.have.property('result_page').to.equal(parameters.result_page);
-        expect(requestParams).to.have.property('result_id').to.equal(parameters.result_id);
-        expect(requestParams).to.have.property('section').to.equal(parameters.section);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.contain('There is no item with item_id="non-existent-item-id"');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationClick(parameters)).to.equal(true);
+      expect(tracker.trackRecommendationClick(
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackRecommendationClick([])).to.be.an('error');
+      expect(tracker.trackRecommendationClick([], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackRecommendationClick()).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackRecommendationClick(null, userParameters)).to.be.an('error');
     });
   });
 
@@ -3119,6 +3120,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('sort_by').to.equal(requiredParameters.sort_by);
         expect(requestParams).to.have.property('sort_order').to.equal(requiredParameters.sort_order);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
@@ -3367,6 +3369,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
@@ -3679,6 +3682,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1110,7 +1110,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackSearchResultsLoaded', () => {
+  describe('trackSearchResultsLoaded', () => {
     const term = 'Cat in the Hat';
     const requiredParameters = {
       num_results: 1337,
@@ -1687,24 +1687,22 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackConversion', () => {
+  describe.only('trackConversion', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
-      item_id: 'customer-id',
+      item_id: 'labradoodle',
       revenue: 123,
       section: 'Products',
     };
-
     const optionalParameters = {
       item_name: 'item_name',
-      variation_id: 'variation-id',
+      variation_id: 'labradoodle-brown',
     };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1722,7 +1720,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -1731,14 +1728,13 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackConversion(term, requiredParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required parameters, and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1758,7 +1754,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('item_name').to.equal(optionalParameters.item_name);
         expect(requestParams).to.have.property('variation_id').to.equal(optionalParameters.variation_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -1767,7 +1762,11 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, Object.assign({}, requiredParameters, optionalParameters))).to.equal(true);
+      expect(tracker.trackConversion(
+        term,
+        Object.assign({}, requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should respond with a valid response and section should be defaulted when term and required parameters are provided', (done) => {
@@ -1775,7 +1774,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1794,42 +1792,14 @@ describe.only('ConstructorIO - Tracker', () => {
 
       delete clonedParameters.section;
 
-      expect(tracker.trackConversion(term, clonedParameters)).to.equal(true);
+      expect(tracker.trackConversion(term, clonedParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
+    it('Should respond with a valid response when term, required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1846,16 +1816,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackConversion(term, requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1872,14 +1870,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackConversion(term, requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required parameters and conversion type are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
       const fullParameters = Object.assign({}, requiredParameters, {
         type: 'add_to_wishlist',
@@ -1899,14 +2005,13 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+      expect(tracker.trackConversion(term, fullParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required parameters and custom conversion type are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
       const fullParameters = Object.assign({}, requiredParameters, {
         type: 'add_to_loves',
@@ -1930,20 +2035,19 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+      expect(tracker.trackConversion(term, fullParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response when no term is provided, but parameters are', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackConversion(null, requiredParameters)).to.equal(true);
+      expect(tracker.trackConversion(null, requiredParameters, userParameters)).to.equal(true);
     });
 
-    it('should respond with a valid response if is_custom_type is true, display_name is provided, and no type is specified', (done) => {
+    it('Should respond with a valid response if is_custom_type is true, display_name is provided, and no type is specified', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
       const fullParameters = Object.assign({}, requiredParameters, {
         display_name: 'Add To Loves List',
@@ -1966,14 +2070,52 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+      expect(tracker.trackConversion(term, fullParameters, userParameters)).to.equal(true);
     });
 
-    it('should respond with an error if is_custom_type is true, type is provided, and no display_name is specified', (done) => {
+    it('Should support v1 endpoint arguments', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
+      });
+      const parameters = {
+        customer_id: 'labradoodle',
+        name: 'name',
+        section: 'Products',
+        revenue: 123,
+      };
+
+      tracker.on('success', (responseParams) => {
+        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(queryParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('item_id').to.equal(parameters.customer_id);
+        expect(requestParams).to.have.property('item_name').to.equal(parameters.name);
+        expect(requestParams).to.have.property('revenue').to.equal(parameters.revenue.toString());
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, parameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with an error if is_custom_type is true, type is provided, and no display_name is specified', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
       });
       const fullParameters = Object.assign({}, requiredParameters, {
         type: 'add_to_loves',
@@ -1996,111 +2138,19 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
-    });
-
-    it('should support v1 endpoint arguments', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      const parameters = {
-        customer_id: 'customer-id',
-        name: 'name',
-        section: 'Products',
-        revenue: 123,
-      };
-
-      tracker.on('success', (responseParams) => {
-        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(queryParams).to.have.property('section').to.equal(parameters.section);
-        expect(requestParams).to.have.property('key');
-        expect(requestParams).to.have.property('i');
-        expect(requestParams).to.have.property('s');
-        expect(requestParams).to.have.property('c').to.equal(clientVersion);
-        expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('item_id').to.equal(parameters.customer_id);
-        expect(requestParams).to.have.property('item_name').to.equal(parameters.name);
-        expect(requestParams).to.have.property('revenue').to.equal(parameters.revenue.toString());
-        expect(requestParams).to.have.property('section').to.equal(parameters.section);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackConversion(term, parameters)).to.equal(true);
+      expect(tracker.trackConversion(term, fullParameters, userParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultClick(term, [])).to.be.an('error');
+      expect(tracker.trackSearchResultClick(term, [], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultClick(term)).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultClick(term, null, userParameters)).to.be.an('error');
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -68,6 +68,33 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackSessionStart(userParameters)).to.equal(true);
     });
 
+    it('Should respond with a valid response with ui', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart({
+        userParameters,
+        userId,
+      })).to.equal(true);
+    });
+
     it('Should respond with a valid response with segments', (done) => {
       const segments = ['foo', 'bar'];
       const { tracker } = new ConstructorIO({
@@ -152,6 +179,85 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackSessionStart({
         ...userParameters,
         testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with security token', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart(userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response with user ip', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart({
+        ...userParameters,
+        userIp,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response with user agent', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSessionStart({
+        ...userParameters,
+        userAgent,
       })).to.equal(true);
     });
   });

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -21,8 +21,8 @@ describe.only('ConstructorIO - Tracker', () => {
   const clientVersion = 'cio-mocha';
   let fetchSpy = null;
   const userParameters = {
-    i: '6c73138f-c27b-49f0-872d-63b00ed0e395',
-    s: 1,
+    clientId: '6c73138f-c27b-49f0-872d-63b00ed0e395',
+    sessionId: 1,
   };
 
   jsdom({ url: 'http://localhost' });
@@ -44,7 +44,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -58,7 +57,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('action').to.equal('session_start');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -67,16 +65,14 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSessionStart()).to.equal(true);
+      expect(tracker.trackSessionStart(userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response with segments', (done) => {
       const segments = ['foo', 'bar'];
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -93,107 +89,10 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSessionStart()).to.equal(true);
-    });
-
-    it('Should respond with a valid response with userId', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
+      expect(tracker.trackSessionStart({
         ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('ui').to.equal(userId);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSessionStart()).to.equal(true);
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is not defined', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSessionStart()).to.equal(true);
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSessionStart()).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSessionStart()).to.equal(true);
+        segments,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response with testCells', (done) => {
@@ -201,8 +100,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -219,7 +116,10 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSessionStart()).to.equal(true);
+      expect(tracker.trackSessionStart({
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response with multiple testCells', (done) => {
@@ -231,8 +131,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -251,7 +149,10 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSessionStart()).to.equal(true);
+      expect(tracker.trackSessionStart({
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -2774,7 +2774,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackRecommendationClick', () => {
+  describe('trackRecommendationClick', () => {
     // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog
     const requiredParameters = {
       pod_id: 'test_pod_id',
@@ -3394,7 +3394,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackBrowseResultClick', () => {
+  describe.only('trackBrowseResultClick', () => {
     // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog
     const requiredParameters = {
       item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
@@ -3415,7 +3415,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3428,11 +3427,10 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('beacon').to.equal('true');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -3441,7 +3439,7 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultClick(requiredParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
@@ -3449,7 +3447,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3468,42 +3465,14 @@ describe.only('ConstructorIO - Tracker', () => {
 
       delete clonedParameters.section;
 
-      expect(tracker.trackBrowseResultClick(clonedParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultClick(clonedParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
+    it('Should respond with a valid response when required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message');
-
-        done();
-      });
-
-      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3520,16 +3489,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3546,14 +3543,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3576,14 +3681,16 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultClick(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+      expect(tracker.trackBrowseResultClick(
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
       const parameters = {
         ...requiredParameters,
@@ -3611,108 +3718,21 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        ...userParameters,
-        beaconMode: false,
-      });
-      const parameters = {
-        ...requiredParameters,
-        ...optionalParameters,
-        item_id: 'non-existent-item-id',
-      };
-
-      tracker.on('error', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('section').to.equal(parameters.section);
-        expect(requestParams).to.have.property('result_count').to.equal(parameters.result_count);
-        expect(requestParams).to.have.property('result_page').to.equal(parameters.result_page);
-        expect(requestParams).to.have.property('result_id').to.equal(parameters.result_id);
-        expect(requestParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
-        expect(requestParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
-        expect(requestParams).to.have.property('selected_filters').to.deep.equal(parameters.selected_filters);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.contain('There is no item with item_id="non-existent-item-id"');
-
-        done();
-      });
-
-      expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
+      expect(tracker.trackBrowseResultClick(parameters, userParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackBrowseResultClick([])).to.be.an('error');
+      expect(tracker.trackBrowseResultClick([], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackBrowseResultClick()).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultClick(null, userParameters)).to.be.an('error');
     });
   });
-
 
   describe('trackGenericResultClick', () => {
     // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -828,7 +828,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackSearchSubmit', () => {
+  describe('trackSearchSubmit', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       original_query: 'original-query',
@@ -1411,7 +1411,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackSearchResultClick', () => {
+  describe.only('trackSearchResultClick', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       name: 'name',
@@ -1423,7 +1423,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1439,7 +1438,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('name').to.equal(requiredParameters.name);
         expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.customer_id);
         expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1448,42 +1446,14 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultClick(term, requiredParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
+    it('Should respond with a valid response when term, required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1500,16 +1470,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1526,14 +1524,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required parameters and variation id is provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -1553,81 +1659,31 @@ describe.only('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchResultClick(term, {
         ...requiredParameters,
         variation_id: 'variation-id',
-      })).to.equal(true);
+      }, userParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultClick([], requiredParameters)).to.be.an('error');
+      expect(tracker.trackSearchResultClick([], requiredParameters, userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultClick(null, requiredParameters)).to.be.an('error');
+      expect(tracker.trackSearchResultClick(null, requiredParameters, userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultClick(term, [])).to.be.an('error');
+      expect(tracker.trackSearchResultClick(term, [], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchResultClick(term)).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchResultClick(term, null, userParameters)).to.be.an('error');
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -2475,7 +2475,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackRecommendationView', () => {
+  describe('trackRecommendationView', () => {
     const requiredParameters = {
       pod_id: 'test_pod_id',
       num_results_viewed: 5,
@@ -3078,7 +3078,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackBrowseResultsLoaded', () => {
+  describe.only('trackBrowseResultsLoaded', () => {
     const requiredParameters = {
       sort_by: 'price',
       sort_order: 'ascending',
@@ -3107,7 +3107,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3120,13 +3119,12 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('beacon').to.equal('true');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('sort_by').to.equal(requiredParameters.sort_by);
         expect(requestParams).to.have.property('sort_order').to.equal(requiredParameters.sort_order);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
         expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -3135,7 +3133,7 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
@@ -3143,7 +3141,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3162,42 +3159,14 @@ describe.only('ConstructorIO - Tracker', () => {
 
       delete clonedParameters.section;
 
-      expect(tracker.trackBrowseResultsLoaded(clonedParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultsLoaded(clonedParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
+    it('Should respond with a valid response when required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message');
-
-        done();
-      });
-
-      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3214,16 +3183,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3240,7 +3237,116 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when required and optional parameters are provided', (done) => {
@@ -3269,69 +3375,22 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackBrowseResultsLoaded(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+      expect(tracker.trackBrowseResultsLoaded(
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackBrowseResultsLoaded([])).to.be.an('error');
+      expect(tracker.trackBrowseResultsLoaded([], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackBrowseResultsLoaded()).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
+      expect(tracker.trackBrowseResultsLoaded(null, userParameters)).to.be.an('error');
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -291,7 +291,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackInputFocus', () => {
+  describe('trackInputFocus', () => {
     it('Should respond with a valid response', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -541,7 +541,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackAutocompleteSelect', () => {
+  describe.only('trackAutocompleteSelect', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       original_query: 'original-query',
@@ -558,7 +558,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -574,7 +573,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -583,16 +581,42 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term and required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('ui').to.equal(userId);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
+        userId,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
       const segments = ['foo', 'bar'];
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -609,42 +633,17 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
         ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('ui').to.equal(userId);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+        segments,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when term, required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -661,14 +660,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
+        testCells,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -689,86 +796,39 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackAutocompleteSelect(term, Object.assign(requiredParameters, optionalParameters)))
-        .to.equal(true);
+      expect(tracker.trackAutocompleteSelect(
+        term,
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should throw an error when invalid term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackAutocompleteSelect([], requiredParameters)).to.be.an('error');
+      expect(tracker.trackAutocompleteSelect([], requiredParameters, userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackAutocompleteSelect(null, requiredParameters)).to.be.an('error');
+      expect(tracker.trackAutocompleteSelect(null, requiredParameters, userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackAutocompleteSelect(term, [])).to.be.an('error');
+      expect(tracker.trackAutocompleteSelect(term, [], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackAutocompleteSelect(term)).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackAutocompleteSelect(term, null, userParameters)).to.be.an('error');
     });
   });
 
-  describe('trackSearchSubmit', () => {
+  describe.only('trackSearchSubmit', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       original_query: 'original-query',
@@ -783,7 +843,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -798,7 +857,6 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
         expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -807,42 +865,14 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchSubmit(term, requiredParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
+    it('Should respond with a valid response when term, required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when term, required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -859,16 +889,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when term, required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -885,14 +943,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when term, required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -912,81 +1078,35 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchSubmit(term, Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+      expect(tracker.trackSearchSubmit(
+        term,
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should throw an error when invalid term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchSubmit([], requiredParameters)).to.be.an('error');
+      expect(tracker.trackSearchSubmit([], requiredParameters), userParameters).to.be.an('error');
     });
 
     it('Should throw an error when no term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchSubmit(null, requiredParameters)).to.be.an('error');
+      expect(tracker.trackSearchSubmit(null, requiredParameters), userParameters).to.be.an('error');
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchSubmit(term, [])).to.be.an('error');
+      expect(tracker.trackSearchSubmit(term, [], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackSearchSubmit(term)).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('GET');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
+      expect(tracker.trackSearchSubmit(term, null, userParameters)).to.be.an('error');
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -3078,7 +3078,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackBrowseResultsLoaded', () => {
+  describe('trackBrowseResultsLoaded', () => {
     const requiredParameters = {
       sort_by: 'price',
       sort_order: 'ascending',
@@ -3394,7 +3394,7 @@ describe.only('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackBrowseResultClick', () => {
+  describe('trackBrowseResultClick', () => {
     // Note: `variation_id` parameter not being passed as none are defined for this item_id in catalog
     const requiredParameters = {
       item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
@@ -3748,7 +3748,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3761,8 +3760,7 @@ describe.only('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('beacon').to.equal('true');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        expect(requestParams).to.have.property('beacon').to.equal(true);
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
 
         // Response
@@ -3772,7 +3770,7 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackGenericResultClick(requiredParameters, userParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response and section should be defaulted when required parameters are provided', (done) => {
@@ -3780,7 +3778,6 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3799,42 +3796,14 @@ describe.only('ConstructorIO - Tracker', () => {
 
       delete clonedParameters.section;
 
-      expect(tracker.trackGenericResultClick(clonedParameters)).to.equal(true);
+      expect(tracker.trackGenericResultClick(clonedParameters, userParameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
-      const segments = ['foo', 'bar'];
+    it('Should respond with a valid response when required parameters and user identifier are provided', (done) => {
+      const userId = 'bd2d9d1f097614c4b4de';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
-        segments,
         fetch: fetchSpy,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('us').to.deep.equal(segments);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message');
-
-        done();
-      });
-
-      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and userId are provided', (done) => {
-      const userId = 'user-id';
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3851,16 +3820,44 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        ...userParameters,
+        userId,
+      })).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and testCells are provided', (done) => {
+    it('Should respond with a valid response when required parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('us').to.deep.equal(segments);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        ...userParameters,
+        segments,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when required parameters and test cells are provided', (done) => {
       const testCells = { foo: 'bar' };
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        testCells,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3879,14 +3876,122 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        ...userParameters,
+        testCells,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and origin referrer are provided', (done) => {
+      const originReferrer = 'https://localhost';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        originReferrer,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and security token are provided', (done) => {
+      const securityToken = '5219c4c62f24e9b39ef92979';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        securityToken,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('x-cnstrc-token').to.equal(securityToken);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user ip are provided', (done) => {
+      const userIp = '127.0.0.1';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        userIp,
+        ...userParameters,
+      })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and user agent are provided', (done) => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestedHeaders = helpers.extractHeadersFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedHeaders).to.have.property('User-Agent').to.equal(userAgent);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, {
+        userAgent,
+        ...userParameters,
+      })).to.equal(true);
     });
 
     it('Should respond with a valid response when required and optional parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
       tracker.on('success', (responseParams) => {
@@ -3905,14 +4010,16 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackGenericResultClick(Object.assign(requiredParameters, optionalParameters))).to.equal(true);
+      expect(tracker.trackGenericResultClick(
+        Object.assign(requiredParameters, optionalParameters),
+        userParameters,
+      )).to.equal(true);
     });
 
     it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
       const parameters = {
         ...requiredParameters,
@@ -3936,103 +4043,19 @@ describe.only('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackGenericResultClick(parameters)).to.equal(true);
-    });
-
-    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        ...userParameters,
-        beaconMode: false,
-      });
-      const parameters = {
-        ...requiredParameters,
-        ...optionalParameters,
-        item_id: 'non-existent-item-id',
-      };
-
-      tracker.on('error', (responseParams) => {
-        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('section').to.equal(parameters.section);
-        expect(requestParams).to.have.property('item_id').to.equal(parameters.item_id);
-        expect(requestParams).to.have.property('item_name').to.equal(parameters.item_name);
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams)
-          .to.have.property('message')
-          .to.contain('There is no item with item_id="non-existent-item-id"');
-
-        done();
-      });
-
-      expect(tracker.trackGenericResultClick(parameters)).to.equal(true);
+      expect(tracker.trackGenericResultClick(parameters, userParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackGenericResultClick([])).to.be.an('error');
+      expect(tracker.trackGenericResultClick([], userParameters)).to.be.an('error');
     });
 
     it('Should throw an error when no parameters are provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
-      expect(tracker.trackGenericResultClick()).to.be.an('error');
-    });
-
-    it('Should send along origin_referrer query param if sendReferrerWithTrackingEvents is true', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: true,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
-    });
-
-    it('Should not send along origin_referrer query param if sendReferrerWithTrackingEvents is false', (done) => {
-      const { tracker } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-        sendReferrerWithTrackingEvents: false,
-        ...userParameters,
-      });
-
-      tracker.on('success', (responseParams) => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        // Request
-        expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.not.have.property('origin_referrer');
-
-        // Response
-        expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('ok');
-
-        done();
-      });
-
-      expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
+      expect(tracker.trackGenericResultClick(null, userParameters)).to.be.an('error');
     });
   });
 
@@ -4065,10 +4088,9 @@ describe.only('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
-        ...userParameters,
       });
 
-      tracker.trackSessionStart();
+      tracker.trackSessionStart(userParameters);
 
       tracker.on('success', (response) => {
         expect(response).to.have.property('url');
@@ -4083,10 +4105,9 @@ describe.only('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         serviceUrl: 'http://constructor.io',
-        ...userParameters,
       });
 
-      tracker.trackSessionStart();
+      tracker.trackSessionStart(userParameters);
 
       tracker.on('error', (response) => {
         expect(response).to.have.property('url');
@@ -4101,10 +4122,9 @@ describe.only('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         serviceUrl: 'invalid',
-        ...userParameters,
       });
 
-      tracker.trackSessionStart();
+      tracker.trackSessionStart(userParameters);
 
       tracker.on('error', (response) => {
         expect(response).to.have.property('url');

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -5,6 +5,7 @@ const Search = require('./modules/search');
 const Browse = require('./modules/browse');
 const Autocomplete = require('./modules/autocomplete');
 const Recommendations = require('./modules/recommendations');
+const Tracker = require('./modules/tracker');
 const Catalog = require('./modules/catalog');
 const { version: packageVersion } = require('../package.json');
 
@@ -22,6 +23,7 @@ class ConstructorIO {
    * @property {object} [browse] - Interface to {@link module:browse}
    * @property {object} [autocomplete] - Interface to {@link module:autocomplete}
    * @property {object} [recommendations] - Interface to {@link module:recommendations}
+   * @property {object} [tracker] - Interface to {@link module:tracker}
    * @property {object} [catalog] - Interface to {@link module:catalog}
    * @returns {class}
    */
@@ -53,6 +55,7 @@ class ConstructorIO {
     this.browse = new Browse(this.options);
     this.autocomplete = new Autocomplete(this.options);
     this.recommendations = new Recommendations(this.options);
+    this.tracker = new Tracker(this.options);
     this.catalog = new Catalog(this.options);
   }
 }

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1060,7 +1060,7 @@ class Tracker {
    */
   trackGenericResultClick(parameters, userParameters) {
     // Ensure required parameters are provided
-    if (typeof parameters === 'object' && !!parameters.item_id) {
+    if (typeof parameters === 'object' && parameters && parameters.item_id) {
       const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/result_click?`;
       const bodyParams = {};
       const {
@@ -1083,7 +1083,7 @@ class Tracker {
 
       const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
-      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+      const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -912,7 +912,7 @@ class Tracker {
 
       const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
-      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+      const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1,0 +1,985 @@
+/* eslint-disable camelcase, no-underscore-dangle, no-unneeded-ternary, brace-style */
+const qs = require('qs');
+const nodeFetch = require('node-fetch');
+const EventEmitter = require('events');
+const helpers = require('../utils/helpers');
+
+function applyParams(parameters, options) {
+  const {
+    apiKey,
+    version,
+    sessionId,
+    clientId,
+    userId,
+    segments,
+    testCells,
+    requestMethod,
+    beaconMode,
+  } = options;
+  const { host, pathname } = helpers.getWindowLocation();
+  const sendReferrerWithTrackingEvents = (options.sendReferrerWithTrackingEvents === false)
+    ? false
+    : true; // Defaults to 'true'
+  let aggregateParams = Object.assign(parameters);
+
+  if (version) {
+    aggregateParams.c = version;
+  }
+
+  if (clientId) {
+    aggregateParams.i = clientId;
+  }
+
+  if (sessionId) {
+    aggregateParams.s = sessionId;
+  }
+
+  if (userId) {
+    aggregateParams.ui = userId;
+  }
+
+  if (segments && segments.length) {
+    aggregateParams.us = segments;
+  }
+
+  if (apiKey) {
+    aggregateParams.key = apiKey;
+  }
+
+  if (testCells) {
+    Object.keys(testCells).forEach((testCellKey) => {
+      aggregateParams[`ef-${testCellKey}`] = testCells[testCellKey];
+    });
+  }
+
+  if (beaconMode && requestMethod && requestMethod.match(/POST/i)) {
+    aggregateParams.beacon = true;
+  }
+
+  if (sendReferrerWithTrackingEvents && host) {
+    aggregateParams.origin_referrer = host;
+
+    if (pathname) {
+      aggregateParams.origin_referrer += pathname;
+    }
+  }
+
+  aggregateParams._dt = Date.now();
+  aggregateParams = helpers.cleanParams(aggregateParams);
+
+  return aggregateParams;
+}
+
+// Append common parameters to supplied parameters object and return as string
+function applyParamsAsString(parameters, options) {
+  return qs.stringify(applyParams(parameters, options), { indices: false });
+}
+
+// Send request to server
+function send(url, method = 'GET', body) {
+  let request;
+
+  if (method === 'GET') {
+    request = nodeFetch(url);
+  }
+
+  if (method === 'POST') {
+    request = nodeFetch(url, {
+      method,
+      body: JSON.stringify(body),
+      mode: 'cors',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  if (request) {
+    const instance = this;
+
+    request.then((response) => {
+      // Request was successful, and returned a 2XX status code
+      if (response.ok) {
+        instance.eventemitter.emit('success', {
+          url,
+          method,
+          message: 'ok',
+        });
+      }
+
+      // Request was successful, but returned a non-2XX status code
+      else {
+        response.json().then((json) => {
+          instance.eventemitter.emit('error', {
+            url,
+            method,
+            message: json && json.message,
+          });
+        }).catch((error) => {
+          instance.eventemitter.emit('error', {
+            url,
+            method,
+            message: error.type,
+          });
+        });
+      }
+    }).catch((error) => {
+      instance.eventemitter.emit('error', {
+        url,
+        method,
+        message: error.toString(),
+      });
+    });
+  }
+}
+
+/**
+ * Interface to tracking related API calls
+ *
+ * @module tracker
+ * @inner
+ * @returns {object}
+ */
+class Tracker {
+  constructor(options) {
+    this.options = options || {};
+    this.eventemitter = new EventEmitter();
+  }
+
+  /**
+   * Send session start event to API
+   *
+   * @function trackSessionStart
+   * @returns {(true|Error)}
+   */
+  trackSessionStart() {
+    const url = `${this.options.serviceUrl}/behavior?`;
+    const queryParams = { action: 'session_start' };
+
+    send(`${url}${applyParamsAsString(queryParams, this.options)}`);
+
+    return true;
+  }
+
+  /**
+   * Send input focus event to API
+   *
+   * @function trackInputFocus
+   * @returns {(true|Error)}
+   * @description User focused on search input element
+   */
+  trackInputFocus() {
+    const url = `${this.options.serviceUrl}/behavior?`;
+    const queryParams = { action: 'focus' };
+
+    send(`${url}${applyParamsAsString(queryParams, this.options)}`);
+
+    return true;
+  }
+
+  /**
+   * Send autocomplete select event to API
+   *
+   * @function trackAutocompleteSelect
+   * @param {string} term - Term of selected autocomplete item
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} parameters.original_query - The current autocomplete search query
+   * @param {string} parameters.result_id - Customer id of the selected autocomplete item
+   * @param {string} parameters.section - Section the selected item resides within
+   * @param {string} [parameters.tr] - Trigger used to select the item (click, etc.)
+   * @param {string} [parameters.group_id] - Group identifier of selected item
+   * @param {string} [parameters.display_name] - Display name of group of selected item
+   * @returns {(true|Error)}
+   * @description User selected (clicked, or navigated to via keyboard) a result that appeared within autocomplete
+   */
+  trackAutocompleteSelect(term, parameters) {
+    // Ensure term is provided (required)
+    if (term && typeof term === 'string') {
+      // Ensure parameters are provided (required)
+      if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.ourEncodeURIComponent(term)}/select?`;
+        const queryParams = {};
+        const {
+          original_query,
+          result_id,
+          section,
+          original_section,
+          tr,
+          group_id,
+          display_name,
+        } = parameters;
+
+        if (original_query) {
+          queryParams.original_query = original_query;
+        }
+
+        if (tr) {
+          queryParams.tr = tr;
+        }
+
+        if (original_section || section) {
+          queryParams.section = original_section || section;
+        }
+
+        if (group_id) {
+          queryParams.group = {
+            group_id,
+            display_name,
+          };
+        }
+
+        if (result_id) {
+          queryParams.result_id = result_id;
+        }
+
+        send(`${url}${applyParamsAsString(queryParams, this.options)}`);
+
+        return true;
+      }
+
+      return new Error('parameters are required of type object');
+    }
+
+    return new Error('term is a required parameter of type string');
+  }
+
+  /**
+   * Send autocomplete search event to API
+   *
+   * @function trackSearchSubmit
+   * @param {string} term - Term of submitted autocomplete event
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} parameters.original_query - The current autocomplete search query
+   * @param {string} parameters.result_id - Customer ID of the selected autocomplete item
+   * @param {string} [parameters.group_id] - Group identifier of selected item
+   * @param {string} [parameters.display_name] - Display name of group of selected item
+   * @returns {(true|Error)}
+   * @description User submitted a search (pressing enter within input element, or clicking submit element)
+   */
+  trackSearchSubmit(term, parameters) {
+    // Ensure term is provided (required)
+    if (term && typeof term === 'string') {
+      // Ensure parameters are provided (required)
+      if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.ourEncodeURIComponent(term)}/search?`;
+        const queryParams = {};
+        const { original_query, result_id, group_id, display_name } = parameters;
+
+        if (original_query) {
+          queryParams.original_query = original_query;
+        }
+
+        if (group_id) {
+          queryParams.group = {
+            group_id,
+            display_name,
+          };
+        }
+
+        if (result_id) {
+          queryParams.result_id = result_id;
+        }
+
+        send(`${url}${applyParamsAsString(queryParams, this.options)}`);
+
+        return true;
+      }
+
+      return new Error('parameters are required of type object');
+    }
+
+    return new Error('term is a required parameter of type string');
+  }
+
+  /**
+   * Send search results event to API
+   *
+   * @function trackSearchResultsLoaded
+   * @param {string} term - Search results query term
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {number} parameters.num_results - Number of search results in total
+   * @param {array} [parameters.customer_ids] - List of customer item id's returned from search
+   * @returns {(true|Error)}
+   * @description User loaded a search product listing page
+   */
+  trackSearchResultsLoaded(term, parameters) {
+    // Ensure term is provided (required)
+    if (term && typeof term === 'string') {
+      // Ensure parameters are provided (required)
+      if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+        const url = `${this.options.serviceUrl}/behavior?`;
+        const queryParams = { action: 'search-results', term };
+        const { num_results, customer_ids } = parameters;
+
+        if (!helpers.isNil(num_results)) {
+          queryParams.num_results = num_results;
+        }
+
+        if (customer_ids && Array.isArray(customer_ids)) {
+          queryParams.customer_ids = customer_ids.join(',');
+        }
+
+        send(`${url}${applyParamsAsString(queryParams, this.options)}`);
+
+        return true;
+      }
+
+      return new Error('parameters are required of type object');
+    }
+
+    return new Error('term is a required parameter of type string');
+  }
+
+  /**
+   * Send click through event to API
+   *
+   * @function trackSearchResultClick
+   * @param {string} term - Search results query term
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} parameters.name - Identifier
+   * @param {string} parameters.customer_id - Customer id
+   * @param {string} [parameters.result_id] - Result id
+   * @returns {(true|Error)}
+   * @description User clicked a result that appeared within a search product listing page
+   */
+  trackSearchResultClick(term, parameters) {
+    // Ensure term is provided (required)
+    if (term && typeof term === 'string') {
+      // Ensure parameters are provided (required)
+      if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.ourEncodeURIComponent(term)}/click_through?`;
+        const queryParams = {};
+        const { name, customer_id, variation_id, result_id } = parameters;
+
+        if (name) {
+          queryParams.name = name;
+        }
+
+        if (customer_id) {
+          queryParams.customer_id = customer_id;
+        }
+
+        if (variation_id) {
+          queryParams.variation_id = variation_id;
+        }
+
+        if (result_id) {
+          queryParams.result_id = result_id;
+        }
+
+        send(`${url}${applyParamsAsString(queryParams, this.options)}`);
+
+        return true;
+      }
+
+      return new Error('parameters are required of type object');
+    }
+
+    return new Error('term is a required parameter of type string');
+  }
+
+  /**
+   * Send conversion event to API
+   *
+   * @function trackConversion
+   * @param {string} term - Search results query term
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} parameters.customer_id - Customer id
+   * @param {string} parameters.revenue - Revenue
+   * @param {string} [parameters.item_name] - Identifier
+   * @param {string} [parameters.variation_id] - Variation id
+   * @param {string} [parameters.type='add_to_cart'] - Conversion type
+   * @param {boolean} [parameters.is_custom_type] - Specify if type is custom conversion type
+   * @param {string} [parameters.display_name] - Display name for the custom conversion type
+   * @param {string} [parameters.result_id] - Result id
+   * @param {string} [parameters.section] - Autocomplete section
+   * @returns {(true|Error)}
+   * @description User performed an action indicating interest in an item (add to cart, add to wishlist, etc.)
+   */
+  trackConversion(term, parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const searchTerm = helpers.ourEncodeURIComponent(term) || 'TERM_UNKNOWN';
+      const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/conversion?`;
+      const queryParams = {};
+      const bodyParams = {};
+      const {
+        name,
+        item_name,
+        item_id,
+        customer_id,
+        variation_id,
+        revenue,
+        section = 'Products',
+        display_name,
+        type,
+        is_custom_type,
+      } = parameters;
+
+      // Only take one of item_id or customer_id
+      if (item_id) {
+        bodyParams.item_id = item_id;
+      } else if (customer_id) {
+        bodyParams.item_id = customer_id;
+      }
+
+      if (item_name) {
+        bodyParams.item_name = item_name;
+      } else if (name) {
+        bodyParams.item_name = name;
+      }
+
+      if (variation_id) {
+        bodyParams.variation_id = variation_id;
+      }
+
+      if (revenue) {
+        bodyParams.revenue = revenue.toString();
+      }
+
+      if (section) {
+        queryParams.section = section;
+        bodyParams.section = section;
+      }
+
+      if (searchTerm) {
+        bodyParams.search_term = searchTerm;
+      }
+
+      if (type) {
+        bodyParams.type = type;
+      }
+
+      if (is_custom_type) {
+        bodyParams.is_custom_type = is_custom_type;
+      }
+
+      if (display_name) {
+        bodyParams.display_name = display_name;
+      }
+
+      const requestURL = `${requestPath}${applyParamsAsString(queryParams, this.options)}`;
+      const requestMethod = 'POST';
+      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+
+      send(
+        requestURL,
+        requestMethod,
+        requestBody,
+      );
+
+      return true;
+    }
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
+   * Send purchase event to API
+   *
+   * @function trackPurchase
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {array} parameters.items - List of objects of customer items returned from browse
+   * @param {number} parameters.revenue - Revenue
+   * @param {string} [parameters.order_id] - Customer unique order identifier
+   * @param {string} [parameters.section] - Autocomplete section
+   * @returns {(true|Error)}
+   * @description User completed an order (usually fired on order confirmation page)
+   */
+  trackPurchase(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/purchase?`;
+      const queryParams = {};
+      const bodyParams = {};
+      const { items, revenue, order_id, section } = parameters;
+
+      if (order_id) {
+        // Don't send another purchase event if we have already tracked the order
+        if (helpers.hasOrderIdRecord(order_id)) {
+          return false;
+        }
+
+        helpers.addOrderIdRecord(order_id);
+
+        // Add order_id to the tracking params
+        bodyParams.order_id = order_id;
+      }
+
+      if (items && Array.isArray(items)) {
+        bodyParams.items = items;
+      }
+
+      if (revenue) {
+        bodyParams.revenue = revenue;
+      }
+
+      if (section) {
+        queryParams.section = section;
+      } else {
+        queryParams.section = 'Products';
+      }
+
+      const requestURL = `${requestPath}${applyParamsAsString(queryParams, this.options)}`;
+      const requestMethod = 'POST';
+      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+
+      send(
+        requestURL,
+        requestMethod,
+        requestBody,
+      );
+
+      return true;
+    }
+
+    this.requests.send();
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
+   * Send recommendation view event to API
+   *
+   * @function trackRecommendationView
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {string} [parameters.result_id] - Result identifier
+   * @param {string} [parameters.section="Products"] - Results section
+   * @param {string} parameters.url - Current page URL
+   * @param {string} parameters.pod_id - Pod identifier
+   * @param {number} parameters.num_results_viewed - Number of results viewed
+   * @returns {(true|Error)}
+   * @description User clicked a result that appeared within a search product listing page
+   */
+  trackRecommendationView(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/recommendation_result_view?`;
+      const bodyParams = {};
+      const {
+        result_count,
+        result_page,
+        result_id,
+        section,
+        url,
+        pod_id,
+        num_results_viewed,
+      } = parameters;
+
+      if (!helpers.isNil(result_count)) {
+        bodyParams.result_count = result_count;
+      }
+
+      if (!helpers.isNil(result_page)) {
+        bodyParams.result_page = result_page;
+      }
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (url) {
+        bodyParams.url = url;
+      }
+
+      if (pod_id) {
+        bodyParams.pod_id = pod_id;
+      }
+
+      if (!helpers.isNil(num_results_viewed)) {
+        bodyParams.num_results_viewed = num_results_viewed;
+      }
+
+      const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;
+      const requestMethod = 'POST';
+      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+
+      send(
+        requestURL,
+        requestMethod,
+        requestBody,
+      );
+
+      return true;
+    }
+
+    this.requests.send();
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
+   * Send recommendation click event to API
+   *
+   * @function trackRecommendationClick
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} [parameters.variation_id] - Variation identifier
+   * @param {string} [parameters.section="Products"] - Results section
+   * @param {string} [parameters.result_id] - Result identifier
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {number} [parameters.result_position_on_page] - Position of result on page
+   * @param {number} [parameters.num_results_per_page] - Number of results on page
+   * @param {string} parameters.pod_id - Pod identifier
+   * @param {string} parameters.strategy_id - Strategy identifier
+   * @param {string} parameters.item_id - Identifier of clicked item
+   * @returns {(true|Error)}
+   * @description User clicked an item that appeared within a list of recommended results
+   */
+  trackRecommendationClick(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/recommendation_result_click?`;
+      const bodyParams = {};
+      const {
+        variation_id,
+        section,
+        result_id,
+        result_count,
+        result_page,
+        result_position_on_page,
+        num_results_per_page,
+        pod_id,
+        strategy_id,
+        item_id,
+      } = parameters;
+
+      if (variation_id) {
+        bodyParams.variation_id = variation_id;
+      }
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (!helpers.isNil(result_count)) {
+        bodyParams.result_count = result_count;
+      }
+
+      if (!helpers.isNil(result_page)) {
+        bodyParams.result_page = result_page;
+      }
+
+      if (!helpers.isNil(result_position_on_page)) {
+        bodyParams.result_position_on_page = result_position_on_page;
+      }
+
+      if (!helpers.isNil(num_results_per_page)) {
+        bodyParams.num_results_per_page = num_results_per_page;
+      }
+
+      if (pod_id) {
+        bodyParams.pod_id = pod_id;
+      }
+
+      if (strategy_id) {
+        bodyParams.strategy_id = strategy_id;
+      }
+
+      if (item_id) {
+        bodyParams.item_id = item_id;
+      }
+
+      const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;
+      const requestMethod = 'POST';
+      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+
+      send(
+        requestURL,
+        requestMethod,
+        requestBody,
+      );
+
+      return true;
+    }
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
+   * Send browse results loaded event to API
+   *
+   * @function trackBrowseResultsLoaded
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} [parameters.section="Products"] - Results section
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {string} [parameters.result_id] - Result identifier
+   * @param {string} [parameters.selected_filters] -  Selected filters
+   * @param {string} [parameters.sort_order] - Sort order ('ascending' or 'descending')
+   * @param {string} [parameters.sort_by] - Sorting method
+   * @param {array} [parameters.items] - List of objects of customer items returned from browse
+   * @param {string} parameters.url - Current page URL
+   * @param {string} parameters.filter_name - Filter name
+   * @param {string} parameters.filter_value - Filter value
+   * @returns {(true|Error)}
+   * @description User loaded a browse product listing page
+   */
+  trackBrowseResultsLoaded(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/browse_result_load?`;
+      const bodyParams = {};
+      const {
+        section,
+        result_count,
+        result_page,
+        result_id,
+        selected_filters,
+        url,
+        sort_order,
+        sort_by,
+        filter_name,
+        filter_value,
+        items,
+      } = parameters;
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (!helpers.isNil(result_count)) {
+        bodyParams.result_count = result_count;
+      }
+
+      if (!helpers.isNil(result_page)) {
+        bodyParams.result_page = result_page;
+      }
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (selected_filters) {
+        bodyParams.selected_filters = selected_filters;
+      }
+
+      if (url) {
+        bodyParams.url = url;
+      }
+
+      if (sort_order) {
+        bodyParams.sort_order = sort_order;
+      }
+
+      if (sort_by) {
+        bodyParams.sort_by = sort_by;
+      }
+
+      if (filter_name) {
+        bodyParams.filter_name = filter_name;
+      }
+
+      if (filter_value) {
+        bodyParams.filter_value = filter_value;
+      }
+
+      if (items && Array.isArray(items)) {
+        bodyParams.items = items;
+      }
+
+      const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;
+      const requestMethod = 'POST';
+      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+
+      send(
+        requestURL,
+        requestMethod,
+        requestBody,
+      );
+
+      return true;
+    }
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
+   * Send browse result click event to API
+   *
+   * @function trackBrowseResultClick
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} [parameters.section="Products"] - Results section
+   * @param {string} [parameters.variation_id] - Variation ID of clicked item
+   * @param {string} [parameters.result_id] - Result identifier
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {number} [parameters.result_position_on_page] - Position of clicked item
+   * @param {number} [parameters.num_results_per_page] - Number of results shown
+   * @param {string} [parameters.selected_filters] -  Selected filters
+   * @param {string} parameters.filter_name - Filter name
+   * @param {string} parameters.filter_value - Filter value
+   * @param {string} parameters.item_id - ID of clicked item
+   * @returns {(true|Error)}
+   * @description User clicked a result that appeared within a browse product listing page
+   */
+  trackBrowseResultClick(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/browse_result_click?`;
+      const bodyParams = {};
+      const {
+        section,
+        variation_id,
+        result_id,
+        result_count,
+        result_page,
+        result_position_on_page,
+        num_results_per_page,
+        selected_filters,
+        filter_name,
+        filter_value,
+        item_id,
+      } = parameters;
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (variation_id) {
+        bodyParams.variation_id = variation_id;
+      }
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (!helpers.isNil(result_count)) {
+        bodyParams.result_count = result_count;
+      }
+
+      if (!helpers.isNil(result_page)) {
+        bodyParams.result_page = result_page;
+      }
+
+      if (!helpers.isNil(result_position_on_page)) {
+        bodyParams.result_position_on_page = result_position_on_page;
+      }
+
+      if (!helpers.isNil(num_results_per_page)) {
+        bodyParams.num_results_per_page = num_results_per_page;
+      }
+
+      if (selected_filters) {
+        bodyParams.selected_filters = selected_filters;
+      }
+
+      if (filter_name) {
+        bodyParams.filter_name = filter_name;
+      }
+
+      if (filter_value) {
+        bodyParams.filter_value = filter_value;
+      }
+
+      if (item_id) {
+        bodyParams.item_id = item_id;
+      }
+
+      const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;
+      const requestMethod = 'POST';
+      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+
+      send(
+        requestURL,
+        requestMethod,
+        requestBody,
+      );
+
+      return true;
+    }
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
+   * Send generic result click event to API
+   *
+   * @function trackGenericResultClick
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} parameters.item_id - ID of clicked item
+   * @param {string} [parameters.item_name] - Name of clicked item
+   * @param {string} [parameters.variation_id] - Variation ID of clicked item
+   * @param {string} [parameters.section="Products"] - Results section
+   * @returns {(true|Error)}
+   * @description User clicked a result that appeared within a browse product listing page
+   */
+  trackGenericResultClick(parameters) {
+    // Ensure required parameters are provided
+    if (typeof parameters === 'object' && !!parameters.item_id) {
+      const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/result_click?`;
+      const bodyParams = {};
+      const {
+        item_id,
+        item_name,
+        variation_id,
+        section,
+      } = parameters;
+
+      bodyParams.section = section || 'Products';
+      bodyParams.item_id = item_id;
+
+      if (item_name) {
+        bodyParams.item_name = item_name;
+      }
+
+      if (variation_id) {
+        bodyParams.variation_id = variation_id;
+      }
+
+      const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;
+      const requestMethod = 'POST';
+      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+
+      send(
+        requestURL,
+        requestMethod,
+        requestBody,
+      );
+
+      return true;
+    }
+
+    return new Error('A parameters object with an "item_id" property is required.');
+  }
+
+  /**
+   * Subscribe to success or error messages emitted by tracking requests
+   *
+   * @function on
+   * @param {string} messageType - Type of message to listen for ('success' or 'error')
+   * @param {function} callback - Callback to be invoked when message received
+   * @returns {(true|Error)}
+   */
+  on(messageType, callback) {
+    if (messageType !== 'success' && messageType !== 'error') {
+      return new Error('messageType must be a string of value "success" or "error"');
+    }
+
+    if (!callback || typeof callback !== 'function') {
+      return new Error('callback is required and must be a function');
+    }
+
+    this.eventemitter.on(messageType, callback);
+
+    return true;
+  }
+}
+
+module.exports = Tracker;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -184,10 +184,11 @@ class Tracker {
   trackSessionStart(userParameters) {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'session_start' };
+    const requestUrl = `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`;
 
     send.call(
       this,
-      `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+      requestUrl,
       userParameters,
     );
 
@@ -215,10 +216,11 @@ class Tracker {
   trackInputFocus(userParameters) {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'focus' };
+    const requestUrl = `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`;
 
     send.call(
       this,
-      `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+      requestUrl,
       userParameters,
     );
 
@@ -291,9 +293,11 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
+        const requestUrl = `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`;
+
         send.call(
           this,
-          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          requestUrl,
           userParameters,
         );
 
@@ -354,9 +358,11 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
+        const requestUrl = `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`;
+
         send.call(
           this,
-          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          requestUrl,
           userParameters,
         );
 
@@ -408,9 +414,11 @@ class Tracker {
           queryParams.customer_ids = customer_ids.join(',');
         }
 
+        const requestUrl = `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`;
+
         send.call(
           this,
-          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          requestUrl,
           userParameters,
         );
 
@@ -471,9 +479,11 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
+        const requestUrl = `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`;
+
         send.call(
           this,
-          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          requestUrl,
           userParameters,
         );
 
@@ -577,13 +587,13 @@ class Tracker {
         bodyParams.display_name = display_name;
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString(queryParams, userParameters, this.options)}`;
+      const requestUrl = `${requestPath}${applyParamsAsString(queryParams, userParameters, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
-        requestURL,
+        requestUrl,
         userParameters,
         requestMethod,
         requestBody,
@@ -644,13 +654,13 @@ class Tracker {
         queryParams.section = 'Products';
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString(queryParams, userParameters, this.options)}`;
+      const requestUrl = `${requestPath}${applyParamsAsString(queryParams, userParameters, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
-        requestURL,
+        requestUrl,
         userParameters,
         requestMethod,
         requestBody,
@@ -733,13 +743,13 @@ class Tracker {
         bodyParams.num_results_viewed = num_results_viewed;
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
+      const requestUrl = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
-        requestURL,
+        requestUrl,
         userParameters,
         requestMethod,
         requestBody,
@@ -840,13 +850,13 @@ class Tracker {
         bodyParams.item_id = item_id;
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
+      const requestUrl = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
-        requestURL,
+        requestUrl,
         userParameters,
         requestMethod,
         requestBody,
@@ -953,13 +963,13 @@ class Tracker {
         bodyParams.items = items;
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
+      const requestUrl = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
-        requestURL,
+        requestUrl,
         userParameters,
         requestMethod,
         requestBody,
@@ -1066,13 +1076,13 @@ class Tracker {
         bodyParams.item_id = item_id;
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
+      const requestUrl = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
-        requestURL,
+        requestUrl,
         userParameters,
         requestMethod,
         requestBody,
@@ -1130,13 +1140,13 @@ class Tracker {
         bodyParams.variation_id = variation_id;
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
+      const requestUrl = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
-        requestURL,
+        requestUrl,
         userParameters,
         requestMethod,
         requestBody,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1022,7 +1022,7 @@ class Tracker {
 
       const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
-      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+      const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -4,7 +4,6 @@ const nodeFetch = require('node-fetch');
 const EventEmitter = require('events');
 const helpers = require('../utils/helpers');
 
-// TODO: Add support for new user parameters + tests
 function applyParams(parameters, userParameters, options) {
   const {
     apiKey,
@@ -66,12 +65,28 @@ function applyParamsAsString(parameters, userParameters, options) {
 }
 
 // Send request to server
-function send(url, method = 'GET', body) {
+function send(url, userParameters, method = 'GET', body) {
   let request;
   const fetch = (this.options && this.options.fetch) || nodeFetch;
+  const headers = {};
+
+  // Append security token as 'x-cnstrc-token' if available
+  if (this.options.securityToken && typeof this.options.securityToken === 'string') {
+    headers['x-cnstrc-token'] = this.options.securityToken;
+  }
+
+  // Append user IP as 'X-Forwarded-For' if available
+  if (userParameters.userIp && typeof userParameters.userIp === 'string') {
+    headers['X-Forwarded-For'] = userParameters.userIp;
+  }
+
+  // Append user agent as 'User-Agent' if available
+  if (userParameters.userAgent && typeof userParameters.userAgent === 'string') {
+    headers['User-Agent'] = userParameters.userAgent;
+  }
 
   if (method === 'GET') {
-    request = fetch(url);
+    request = fetch(url, { headers });
   }
 
   if (method === 'POST') {
@@ -79,7 +94,10 @@ function send(url, method = 'GET', body) {
       method,
       body: JSON.stringify(body),
       mode: 'cors',
-      headers: { 'Content-Type': 'text/plain' },
+      headers: {
+        ...headers,
+        'Content-Type': 'text/plain',
+      },
     });
   }
 
@@ -153,7 +171,11 @@ class Tracker {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'session_start' };
 
-    send.call(this, `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`);
+    send.call(
+      this,
+      `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+      userParameters,
+    );
 
     return true;
   }
@@ -177,7 +199,11 @@ class Tracker {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'focus' };
 
-    send(`${url}${applyParamsAsString(queryParams, userParameters, this.options)}`);
+    send.call(
+      this,
+      `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+      userParameters,
+    );
 
     return true;
   }
@@ -245,7 +271,11 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        send(`${url}${applyParamsAsString(queryParams, userParameters, this.options)}`);
+        send.call(
+          this,
+          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          userParameters,
+        );
 
         return true;
       }
@@ -301,7 +331,11 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        send(`${url}${applyParamsAsString(queryParams, userParameters, this.options)}`);
+        send.call(
+          this,
+          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          userParameters,
+        );
 
         return true;
       }
@@ -348,7 +382,11 @@ class Tracker {
           queryParams.customer_ids = customer_ids.join(',');
         }
 
-        send(`${url}${applyParamsAsString(queryParams, userParameters, this.options)}`);
+        send.call(
+          this,
+          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          userParameters,
+        );
 
         return true;
       }
@@ -404,7 +442,11 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        send(`${url}${applyParamsAsString(queryParams, userParameters, this.options)}`);
+        send.call(
+          this,
+          `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`,
+          userParameters,
+        );
 
         return true;
       }
@@ -507,8 +549,10 @@ class Tracker {
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 
-      send(
+      send.call(
+        this,
         requestURL,
+        userParameters,
         requestMethod,
         requestBody,
       );
@@ -577,8 +621,10 @@ class Tracker {
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 
-      send(
+      send.call(
+        this,
         requestURL,
+        userParameters,
         requestMethod,
         requestBody,
       );
@@ -663,8 +709,10 @@ class Tracker {
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 
-      send(
+      send.call(
+        this,
         requestURL,
+        userParameters,
         requestMethod,
         requestBody,
       );
@@ -767,8 +815,10 @@ class Tracker {
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 
-      send(
+      send.call(
+        this,
         requestURL,
+        userParameters,
         requestMethod,
         requestBody,
       );
@@ -875,8 +925,10 @@ class Tracker {
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 
-      send(
+      send.call(
+        this,
         requestURL,
+        userParameters,
         requestMethod,
         requestBody,
       );
@@ -983,8 +1035,10 @@ class Tracker {
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 
-      send(
+      send.call(
+        this,
         requestURL,
+        userParameters,
         requestMethod,
         requestBody,
       );
@@ -1042,8 +1096,10 @@ class Tracker {
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 
-      send(
+      send.call(
+        this,
         requestURL,
+        userParameters,
         requestMethod,
         requestBody,
       );

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -547,7 +547,7 @@ class Tracker {
 
       const requestURL = `${requestPath}${applyParamsAsString(queryParams, userParameters, this.options)}`;
       const requestMethod = 'POST';
-      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+      const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -592,14 +592,6 @@ class Tracker {
       const { items, revenue, order_id, section } = parameters;
 
       if (order_id) {
-        // Don't send another purchase event if we have already tracked the order
-        if (helpers.hasOrderIdRecord(order_id)) {
-          return false;
-        }
-
-        helpers.addOrderIdRecord(order_id);
-
-        // Add order_id to the tracking params
         bodyParams.order_id = order_id;
       }
 
@@ -619,7 +611,7 @@ class Tracker {
 
       const requestURL = `${requestPath}${applyParamsAsString(queryParams, userParameters, this.options)}`;
       const requestMethod = 'POST';
-      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+      const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,
@@ -631,8 +623,6 @@ class Tracker {
 
       return true;
     }
-
-    this.requests.send();
 
     return new Error('parameters are required of type object');
   }
@@ -719,8 +709,6 @@ class Tracker {
 
       return true;
     }
-
-    this.requests.send();
 
     return new Error('parameters are required of type object');
   }

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -86,6 +86,16 @@ function send(url, userParameters, method = 'GET', body) {
     headers['User-Agent'] = userParameters.userAgent;
   }
 
+  // Append language as 'Accept-Language' if available
+  if (userParameters.acceptLanguage && typeof userParameters.acceptLanguage === 'string') {
+    headers['Accept-Language'] = userParameters.acceptLanguage;
+  }
+
+  // Append referrer as 'Referer' if available
+  if (userParameters.referer && typeof userParameters.referer === 'string') {
+    headers.Referer = userParameters.referer;
+  }
+
   if (method === 'GET') {
     request = fetch(url, { headers });
   }
@@ -164,8 +174,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    */
   trackSessionStart(userParameters) {
@@ -191,8 +204,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User focused on search input element
    */
@@ -227,8 +243,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User selected (clicked, or navigated to via keyboard) a result that appeared within autocomplete
    */
@@ -303,8 +322,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User submitted a search (pressing enter within input element, or clicking submit element)
    */
@@ -361,8 +383,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User loaded a search product listing page
    */
@@ -413,8 +438,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User clicked a result that appeared within a search product listing page
    */
@@ -479,8 +507,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User performed an action indicating interest in an item (add to cart, add to wishlist, etc.)
    */
@@ -579,8 +610,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User completed an order (usually fired on order confirmation page)
    */
@@ -646,8 +680,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User clicked a result that appeared within a search product listing page
    */
@@ -735,8 +772,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User clicked an item that appeared within a list of recommended results
    */
@@ -840,8 +880,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User loaded a browse product listing page
    */
@@ -950,8 +993,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User clicked a result that appeared within a browse product listing page
    */
@@ -1053,8 +1099,11 @@ class Tracker {
    * @param {object} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string} [userParameters.segments] - User segments
    * @param {string} [userParameters.testCells] - User test cells
-   * @param {string} [userParameters.userIp] - Origin user IP, from client
-   * @param {string} [userParameters.userAgent] - Origin user agent, from client
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
+   * @param {string} [userParameters.referer] - Client page URL (including path)
+   * @param {string} [userParameters.userIp] - Client user IP
+   * @param {string} [userParameters.userAgent] - Client user agent
+   * @param {string} [userParameters.acceptLanguage] - Client accept language
    * @returns {(true|Error)}
    * @description User clicked a result that appeared within a browse product listing page
    */

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -54,6 +54,7 @@ function applyParams(parameters, userParameters, options) {
   }
 
   aggregateParams._dt = Date.now();
+  aggregateParams.beacon = true;
   aggregateParams = helpers.cleanParams(aggregateParams);
 
   return aggregateParams;
@@ -697,7 +698,7 @@ class Tracker {
 
       const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
-      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+      const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -802,7 +802,7 @@ class Tracker {
 
       const requestURL = `${requestPath}${applyParamsAsString({}, userParameters, this.options)}`;
       const requestMethod = 'POST';
-      const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
+      const requestBody = applyParams(bodyParams, userParameters, { ...this.options, requestMethod });
 
       send.call(
         this,


### PR DESCRIPTION
Adds tracking methods largely inspired by the tracking module from constructorio-client-javascript. The differences are that `userParameters` are passed at method invocation time rather than client invocation time.

As requests originate server side, usual browser request header values need to be supplied within `userParameters`. They are as follows:

`x-cnstrc-token` (supplied at client invocation time)
`X-Forwarded-For`
`Accept-Language`
`Referer`
`User-Agent`

Personalization parameters are also supplied as with other modules.

Tests are comprehensive and ensure all possible request headers are sent correctly for every tracking method.

457/457 tests passing.
98.78% coverage on new tracker module.
93.79% coverage overall.

![Screen Shot 2021-06-30 at 9 24 20 PM](https://user-images.githubusercontent.com/4909263/124060416-3c2ba500-d9ea-11eb-95dd-e54d9f0aa1dd.png)

![Screen Shot 2021-06-30 at 9 30 26 PM](https://user-images.githubusercontent.com/4909263/124060497-67ae8f80-d9ea-11eb-9d9e-f8d378987a6d.png)