### PR TITLE
Update documentation to highlight the importance of binding an observer to error

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var constructorio = new ConstructorIOClient({
 
 ## 4. Retrieve Results
 
-After instantiating an instance of the client, four modules will be exposed as properties to help retrieve data from Constructor.io: `search`, `browse`, `autocomplete`, `recommendations` and `catalog`.
+After instantiating an instance of the client, four modules will be exposed as properties to help retrieve data from Constructor.io: `search`, `browse`, `autocomplete`, `recommendations`, `catalog` and `tracker`.
 
 Full API documentation is available on [Github Pages](https://constructor-io.github.io/constructorio-node)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Constructor.io Node.js client",
   "main": "src/constructorio.js",
   "scripts": {
-    "clean": "sudo rm -rf node_modules package-lock.json",
     "version": "chmod +x ./scripts/verify-node-version.sh && ./scripts/verify-node-version.sh && npm run docs && git add ./docs/*",
     "check-lisc": "license-checker --production --onlyAllow 'Apache-2.0;BSD-3-Clause;MIT'",
     "lint": "chmod 766 .git/hooks/pre-push && eslint 'src/**/*.js' 'spec/**/*.js'",

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1165,7 +1165,10 @@ class Tracker {
    * @param {string} messageType - Type of message to listen for ('success' or 'error')
    * @param {function} callback - Callback to be invoked when message received
    * @returns {(true|Error)}
-   * @description If an error event is emitted and does not have at least one listener registered for the 'error' event, the error is thrown, a stack trace is printed, and the Node.js process exits - it is best practice to always bind a `.on('error')` handler
+   * @description
+   * If an error event is emitted and does not have at least one listener registered for the
+   * 'error' event, the error is thrown, a stack trace is printed, and the Node.js process
+   * exits - it is best practice to always bind a `.on('error')` handler
    * @see https://nodejs.org/api/events.html#events_error_events
    */
   on(messageType, callback) {

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1165,6 +1165,8 @@ class Tracker {
    * @param {string} messageType - Type of message to listen for ('success' or 'error')
    * @param {function} callback - Callback to be invoked when message received
    * @returns {(true|Error)}
+   * @description If an error event is emitted and does not have at least one listener registered for the 'error' event, the error is thrown, a stack trace is printed, and the Node.js process exits - it is best practice to always bind a `.on('error')` handler
+   * @see https://nodejs.org/api/events.html#events_error_events
    */
   on(messageType, callback) {
     if (messageType !== 'success' && messageType !== 'error') {


### PR DESCRIPTION
Using the native Node EventEmitter, if you do not bind to an `error` event that is emitted, it will log a stack trace and exit node. It's a good for us to highlight this in the documentation.