### PR TITLE
Remove result_id requirement from trackSearchSubmit.

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -993,9 +993,7 @@ describe('ConstructorIO - Tracker', () => {
 
   describe('trackSearchSubmit', () => {
     const term = 'Where The Wild Things Are';
-    const requiredParameters = {
-      original_query: 'original-query',
-    };
+    const requiredParameters = { original_query: 'original-query' };
     const optionalParameters = {
       group_id: 'group-id',
       display_name: 'display-name',

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -995,7 +995,6 @@ describe('ConstructorIO - Tracker', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       original_query: 'original-query',
-      result_id: 'result-id',
     };
     const optionalParameters = {
       group_id: 'group-id',
@@ -1020,7 +1019,6 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('beacon').to.equal('true');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
-        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -327,7 +327,6 @@ class Tracker {
    * @param {string} term - Term of submitted autocomplete event
    * @param {object} parameters - Additional parameters to be sent with request
    * @param {string} parameters.original_query - The current autocomplete search query
-   * @param {string} parameters.result_id - Customer ID of the selected autocomplete item
    * @param {string} [parameters.group_id] - Group identifier of selected item
    * @param {string} [parameters.display_name] - Display name of group of selected item
    * @param {object} userParameters - Parameters relevant to the user request
@@ -351,7 +350,7 @@ class Tracker {
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
         const url = `${this.options.serviceUrl}/autocomplete/${helpers.ourEncodeURIComponent(term)}/search?`;
         const queryParams = {};
-        const { original_query, result_id, group_id, display_name } = parameters;
+        const { original_query, group_id, display_name } = parameters;
 
         if (original_query) {
           queryParams.original_query = original_query;
@@ -362,10 +361,6 @@ class Tracker {
             group_id,
             display_name,
           };
-        }
-
-        if (result_id) {
-          queryParams.result_id = result_id;
         }
 
         const requestUrl = `${url}${applyParamsAsString(queryParams, userParameters, this.options)}`;


### PR DESCRIPTION
`result_id` isn't required for `trackSearchSubmit` - remove.