### PR TITLE
[CSL-468] Support fetch timeouts (part 2)

### DIFF
--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -32,20 +32,30 @@ describe('ConstructorIO', () => {
     expect(instance).to.have.property('recommendations');
     expect(instance).to.have.property('browse');
     expect(instance).to.have.property('catalog');
+    expect(instance).to.have.property('tracker');
   });
 
   it('Should return an instance with custom options when valid API key is provided', () => {
     const serviceUrl = 'http://constructor.io';
     const version = 'custom-version';
+    const apiToken = 'token';
+    const securityToken = 'security-token';
+    const networkParameters = { timeout: 5000 };
     const instance = new ConstructorIO({
       ...validOptions,
+      apiToken,
       serviceUrl,
       version,
+      securityToken,
+      networkParameters,
     });
 
     expect(instance).to.be.an('object');
+    expect(instance.options).to.have.property('apiToken').to.equal(apiToken);
     expect(instance.options).to.have.property('serviceUrl').to.equal(serviceUrl);
     expect(instance.options).to.have.property('version').to.equal(version);
+    expect(instance.options).to.have.property('securityToken').to.equal(securityToken);
+    expect(instance.options).to.have.property('networkParameters').to.equal(networkParameters);
   });
 
   it('Should throw an error when invalid API key is provided', () => {

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -343,7 +343,7 @@ describe('ConstructorIO - Autocomplete', () => {
     it('Should be rejected when network request timeout is provided and reached', () => {
       const { autocomplete } = new ConstructorIO(validOptions);
 
-      return expect(autocomplete.getAutocompleteResults(query, {}, {}, { timeout: 10 })).to.eventually.be.rejected;
+      return expect(autocomplete.getAutocompleteResults(query, {}, {}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
     });
 
     it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -352,7 +352,7 @@ describe('ConstructorIO - Autocomplete', () => {
         networkParameters: { timeout: 20 },
       });
 
-      return expect(autocomplete.getAutocompleteResults(query, {}, {})).to.eventually.be.rejected;
+      return expect(autocomplete.getAutocompleteResults(query, {}, {})).to.eventually.be.rejectedWith('The user aborted a request.');
     });
   });
 });

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -340,10 +340,19 @@ describe('ConstructorIO - Autocomplete', () => {
       return expect(autocomplete.getAutocompleteResults(query)).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when request timeout is provided and reached', () => {
+    it('Should be rejected when network request timeout is provided and reached', () => {
       const { autocomplete } = new ConstructorIO(validOptions);
 
       return expect(autocomplete.getAutocompleteResults(query, {}, {}, { timeout: 10 })).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when global network request timeout is provided and reached', () => {
+      const { autocomplete } = new ConstructorIO({
+        ...validOptions,
+        networkParameters: { timeout: 20 },
+      });
+
+      return expect(autocomplete.getAutocompleteResults(query, {}, {})).to.eventually.be.rejected;
     });
   });
 });

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -469,7 +469,7 @@ describe('ConstructorIO - Browse', () => {
         {},
         {},
         { timeout: 10 },
-      )).to.eventually.be.rejected;
+      )).to.eventually.be.rejectedWith('The user aborted a request.');
     });
 
     it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -483,7 +483,7 @@ describe('ConstructorIO - Browse', () => {
         filterValue,
         {},
         {},
-      )).to.eventually.be.rejected;
+      )).to.eventually.be.rejectedWith('The user aborted a request.');
     });
   });
 
@@ -796,7 +796,7 @@ describe('ConstructorIO - Browse', () => {
     it('Should be rejected when network request timeout is provided and reached', () => {
       const { browse } = new ConstructorIO(validOptions);
 
-      return expect(browse.getBrowseResultsForItemIds(ids, {}, {}, { timeout: 10 })).to.eventually.be.rejected;
+      return expect(browse.getBrowseResultsForItemIds(ids, {}, {}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
     });
 
     it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -805,7 +805,7 @@ describe('ConstructorIO - Browse', () => {
         networkParameters: { timeout: 20 },
       });
 
-      return expect(browse.getBrowseResultsForItemIds(ids, {}, {})).to.eventually.be.rejected;
+      return expect(browse.getBrowseResultsForItemIds(ids, {}, {})).to.eventually.be.rejectedWith('The user aborted a request.');
     });
   });
 
@@ -929,7 +929,7 @@ describe('ConstructorIO - Browse', () => {
     it('Should be rejected when network request timeout is provided and reached', () => {
       const { browse } = new ConstructorIO(validOptions);
 
-      return expect(browse.getBrowseGroups({}, {}, { timeout: 10 })).to.eventually.be.rejected;
+      return expect(browse.getBrowseGroups({}, {}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
     });
 
     it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -938,7 +938,7 @@ describe('ConstructorIO - Browse', () => {
         networkParameters: { timeout: 20 },
       });
 
-      return expect(browse.getBrowseGroups({}, {})).to.eventually.be.rejected;
+      return expect(browse.getBrowseGroups({}, {})).to.eventually.be.rejectedWith('The user aborted a request.');
     });
   });
 
@@ -994,7 +994,7 @@ describe('ConstructorIO - Browse', () => {
     it('Should be rejected when network request timeout is provided and reached', () => {
       const { browse } = new ConstructorIO(validOptions);
 
-      return expect(browse.getBrowseFacets({}, {}, { timeout: 10 })).to.eventually.be.rejected;
+      return expect(browse.getBrowseFacets({}, {}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
     });
 
     it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1003,7 +1003,7 @@ describe('ConstructorIO - Browse', () => {
         networkParameters: { timeout: 20 },
       });
 
-      return expect(browse.getBrowseFacets({}, {})).to.eventually.be.rejected;
+      return expect(browse.getBrowseFacets({}, {})).to.eventually.be.rejectedWith('The user aborted a request.');
     });
   });
 });

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -460,7 +460,7 @@ describe('ConstructorIO - Browse', () => {
       return expect(browse.getBrowseResults(filterName, filterValue)).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when request timeout is provided and reached', () => {
+    it('Should be rejected when network request timeout is provided and reached', () => {
       const { browse } = new ConstructorIO(validOptions);
 
       return expect(browse.getBrowseResults(
@@ -469,6 +469,20 @@ describe('ConstructorIO - Browse', () => {
         {},
         {},
         { timeout: 10 },
+      )).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when global network request timeout is provided and reached', () => {
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        networkParameters: { timeout: 10 },
+      });
+
+      return expect(browse.getBrowseResults(
+        filterName,
+        filterValue,
+        {},
+        {},
       )).to.eventually.be.rejected;
     });
   });
@@ -779,10 +793,19 @@ describe('ConstructorIO - Browse', () => {
       return expect(browse.getBrowseResultsForItemIds(ids)).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when request timeout is provided and reached', () => {
+    it('Should be rejected when network request timeout is provided and reached', () => {
       const { browse } = new ConstructorIO(validOptions);
 
       return expect(browse.getBrowseResultsForItemIds(ids, {}, {}, { timeout: 10 })).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when global network request timeout is provided and reached', () => {
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        networkParameters: { timeout: 20 },
+      });
+
+      return expect(browse.getBrowseResultsForItemIds(ids, {}, {})).to.eventually.be.rejected;
     });
   });
 
@@ -903,10 +926,19 @@ describe('ConstructorIO - Browse', () => {
       return expect(browse.getBrowseGroups()).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when request timeout is provided and reached', () => {
+    it('Should be rejected when network request timeout is provided and reached', () => {
       const { browse } = new ConstructorIO(validOptions);
 
       return expect(browse.getBrowseGroups({}, {}, { timeout: 10 })).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when global network request timeout is provided and reached', () => {
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        networkParameters: { timeout: 20 },
+      });
+
+      return expect(browse.getBrowseGroups({}, {})).to.eventually.be.rejected;
     });
   });
 
@@ -959,10 +991,19 @@ describe('ConstructorIO - Browse', () => {
       return expect(browse.getBrowseFacets()).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when request timeout is provided and reached', () => {
+    it('Should be rejected when network request timeout is provided and reached', () => {
       const { browse } = new ConstructorIO(validOptions);
 
       return expect(browse.getBrowseFacets({}, {}, { timeout: 10 })).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when global network request timeout is provided and reached', () => {
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        networkParameters: { timeout: 20 },
+      });
+
+      return expect(browse.getBrowseFacets({}, {})).to.eventually.be.rejected;
     });
   });
 });

--- a/spec/src/modules/catalog.js
+++ b/spec/src/modules/catalog.js
@@ -172,7 +172,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addItem(createMockItem(), { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addItem(createMockItem(), { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -181,7 +181,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addItem(createMockItem())).to.eventually.be.rejected;
+        return expect(catalog.addItem(createMockItem())).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -256,7 +256,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addOrUpdateItem(createMockItem(), { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addOrUpdateItem(createMockItem(), { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -265,7 +265,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addOrUpdateItem(createMockItem())).to.eventually.be.rejected;
+        return expect(catalog.addOrUpdateItem(createMockItem())).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -331,7 +331,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.removeItem(mockItem, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.removeItem(mockItem, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -340,7 +340,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.removeItem(mockItem)).to.eventually.be.rejected;
+        return expect(catalog.removeItem(mockItem)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -415,7 +415,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.modifyItem(mockItem, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.modifyItem(mockItem, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -424,7 +424,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.modifyItem(mockItem)).to.eventually.be.rejected;
+        return expect(catalog.modifyItem(mockItem)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -474,7 +474,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addItemsBatch([createMockItem()], { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addItemsBatch([createMockItem()], { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -483,7 +483,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addItemsBatch([createMockItem()])).to.eventually.be.rejected;
+        return expect(catalog.addItemsBatch([createMockItem()])).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -543,7 +543,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addOrUpdateItemsBatch({ items, section: 'Products' }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addOrUpdateItemsBatch({ items, section: 'Products' }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when network global request timeout is provided and reached', () => {
@@ -552,7 +552,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addOrUpdateItemsBatch({ items, section: 'Products' })).to.eventually.be.rejected;
+        return expect(catalog.addOrUpdateItemsBatch({ items, section: 'Products' })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -626,7 +626,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.removeItemsBatch({ items, section: 'Products' }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.removeItemsBatch({ items, section: 'Products' }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -635,7 +635,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.removeItemsBatch({ items, section: 'Products' })).to.eventually.be.rejected;
+        return expect(catalog.removeItemsBatch({ items, section: 'Products' })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -709,7 +709,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getItem({ id: mockItem.id }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getItem({ id: mockItem.id }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -718,7 +718,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getItem({ id: mockItem.id })).to.eventually.be.rejected;
+        return expect(catalog.getItem({ id: mockItem.id })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -797,7 +797,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getItems({ section: 'Products' }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getItems({ section: 'Products' }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -806,7 +806,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getItems({ section: 'Products' })).to.eventually.be.rejected;
+        return expect(catalog.getItems({ section: 'Products' })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });
@@ -853,7 +853,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addItemGroup(createMockItemGroup(), { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addItemGroup(createMockItemGroup(), { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -862,7 +862,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addItemGroup(createMockItemGroup())).to.eventually.be.rejected;
+        return expect(catalog.addItemGroup(createMockItemGroup())).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -911,7 +911,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addItemGroups([createMockItemGroup()], { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addItemGroups([createMockItemGroup()], { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -920,7 +920,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addItemGroups([createMockItemGroup()])).to.eventually.be.rejected;
+        return expect(catalog.addItemGroups([createMockItemGroup()])).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -995,7 +995,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getItemGroup({ group_id: mockItemGroup.id }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getItemGroup({ group_id: mockItemGroup.id }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1004,7 +1004,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getItemGroup({ group_id: mockItemGroup.id })).to.eventually.be.rejected;
+        return expect(catalog.getItemGroup({ group_id: mockItemGroup.id })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1065,7 +1065,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getItemGroups({ timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getItemGroups({ timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1074,7 +1074,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getItemGroups()).to.eventually.be.rejected;
+        return expect(catalog.getItemGroups()).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1157,7 +1157,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrUpdateItemGroups(
           { item_groups: groups },
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1168,7 +1168,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.addOrUpdateItemGroups(
           { item_groups: groups },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1232,7 +1232,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.modifyItemGroup(mockItemGroup, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.modifyItemGroup(mockItemGroup, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1241,7 +1241,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.modifyItemGroup(mockItemGroup)).to.eventually.be.rejected;
+        return expect(catalog.modifyItemGroup(mockItemGroup)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1306,7 +1306,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.removeItemGroups({ timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.removeItemGroups({ timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1315,7 +1315,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.removeItemGroups()).to.eventually.be.rejected;
+        return expect(catalog.removeItemGroups()).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });
@@ -1386,7 +1386,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOneWaySynonym({
           phrase: createMockOneWaySynonymPhrase(),
           child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1398,7 +1398,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOneWaySynonym({
           phrase: createMockOneWaySynonymPhrase(),
           child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1479,7 +1479,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyOneWaySynonym({
           phrase: mockOneWaySynonymPhrase,
           child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1491,7 +1491,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyOneWaySynonym({
           phrase: mockOneWaySynonymPhrase,
           child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1575,7 +1575,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getOneWaySynonym(
           { phrase: mockOneWaySynonymPhrase },
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1586,7 +1586,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.getOneWaySynonym(
           { phrase: mockOneWaySynonymPhrase },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1666,7 +1666,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getOneWaySynonyms({}, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getOneWaySynonyms({}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1675,7 +1675,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getOneWaySynonyms({})).to.eventually.be.rejected;
+        return expect(catalog.getOneWaySynonyms({})).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1735,7 +1735,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeOneWaySynonym(
           { phrase: mockOneWaySynonymPhrase },
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1746,7 +1746,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.removeOneWaySynonym(
           { phrase: mockOneWaySynonymPhrase },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1803,7 +1803,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.removeOneWaySynonyms({ timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.removeOneWaySynonyms({ timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1812,7 +1812,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.removeOneWaySynonyms()).to.eventually.be.rejected;
+        return expect(catalog.removeOneWaySynonyms()).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });
@@ -1869,7 +1869,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addSynonymGroup(
           { synonyms: [createMockSynonym()] },
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1880,7 +1880,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.addSynonymGroup(
           { synonyms: [createMockSynonym()] },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -1960,7 +1960,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifySynonymGroup({
           id: synonymGroupId,
           synonyms: [mockSynonym],
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -1972,7 +1972,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifySynonymGroup({
           id: synonymGroupId,
           synonyms: [mockSynonym],
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2048,7 +2048,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getSynonymGroup({ id: synonymGroupId }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getSynonymGroup({ id: synonymGroupId }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2057,7 +2057,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejected;
+        return expect(catalog.getSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2134,7 +2134,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getSynonymGroups({}, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getSynonymGroups({}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2143,7 +2143,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getSynonymGroups({})).to.eventually.be.rejected;
+        return expect(catalog.getSynonymGroups({})).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2211,7 +2211,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.removeSynonymGroup({ id: synonymGroupId }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.removeSynonymGroup({ id: synonymGroupId }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2220,7 +2220,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.removeSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejected;
+        return expect(catalog.removeSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2274,7 +2274,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.removeSynonymGroups({ timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.removeSynonymGroups({ timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2283,7 +2283,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.removeSynonymGroups()).to.eventually.be.rejected;
+        return expect(catalog.removeSynonymGroups()).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });
@@ -2342,7 +2342,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addRedirectRule(createMockRedirectRule(), { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addRedirectRule(createMockRedirectRule(), { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2351,7 +2351,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addRedirectRule(createMockRedirectRule())).to.eventually.be.rejected;
+        return expect(catalog.addRedirectRule(createMockRedirectRule())).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2443,7 +2443,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.updateRedirectRule({
           id: redirectRuleId,
           ...mockRedirectRule,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2455,7 +2455,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.updateRedirectRule({
           id: redirectRuleId,
           ...mockRedirectRule,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2548,7 +2548,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyRedirectRule({
           id: redirectRuleId,
           ...mockRedirectRule,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2560,7 +2560,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyRedirectRule({
           id: redirectRuleId,
           ...mockRedirectRule,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2640,7 +2640,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getRedirectRule({ id: redirectRuleId }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getRedirectRule({ id: redirectRuleId }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2649,7 +2649,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getRedirectRule({ id: redirectRuleId })).to.eventually.be.rejected;
+        return expect(catalog.getRedirectRule({ id: redirectRuleId })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2776,7 +2776,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getRedirectRules({}, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getRedirectRules({}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2785,7 +2785,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getRedirectRules({})).to.eventually.be.rejected;
+        return expect(catalog.getRedirectRules({})).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -2865,7 +2865,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.removeRedirectRule({ id: redirectRuleId }, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.removeRedirectRule({ id: redirectRuleId }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -2874,7 +2874,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.removeRedirectRule({ id: redirectRuleId })).to.eventually.be.rejected;
+        return expect(catalog.removeRedirectRule({ id: redirectRuleId })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });
@@ -3071,7 +3071,7 @@ describe('ConstructorIO - Catalog', () => {
           section: 'Products',
         };
 
-        return expect(catalog.replaceCatalog(data, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.replaceCatalog(data, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3085,7 +3085,7 @@ describe('ConstructorIO - Catalog', () => {
           section: 'Products',
         };
 
-        return expect(catalog.replaceCatalog(data)).to.eventually.be.rejected;
+        return expect(catalog.replaceCatalog(data)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -3246,7 +3246,7 @@ describe('ConstructorIO - Catalog', () => {
           section: 'Products',
         };
 
-        return expect(catalog.updateCatalog(data, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.updateCatalog(data, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3260,7 +3260,7 @@ describe('ConstructorIO - Catalog', () => {
           section: 'Products',
         };
 
-        return expect(catalog.updateCatalog(data)).to.eventually.be.rejected;
+        return expect(catalog.updateCatalog(data)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -3421,7 +3421,7 @@ describe('ConstructorIO - Catalog', () => {
           section: 'Products',
         };
 
-        return expect(catalog.patchCatalog(data, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.patchCatalog(data, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3435,7 +3435,7 @@ describe('ConstructorIO - Catalog', () => {
           section: 'Products',
         };
 
-        return expect(catalog.patchCatalog(data)).to.eventually.be.rejected;
+        return expect(catalog.patchCatalog(data)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });
@@ -3510,7 +3510,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addFacetConfiguration(mockFacetConfiguration, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addFacetConfiguration(mockFacetConfiguration, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3519,7 +3519,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejected;
+        return expect(catalog.addFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -3573,7 +3573,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.getFacetConfigurations({}, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.getFacetConfigurations({}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3582,7 +3582,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.getFacetConfigurations({})).to.eventually.be.rejected;
+        return expect(catalog.getFacetConfigurations({})).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -3631,7 +3631,7 @@ describe('ConstructorIO - Catalog', () => {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
-        return expect(catalog.addFacetConfiguration(mockFacetConfiguration, { timeout: 10 })).to.eventually.be.rejected;
+        return expect(catalog.addFacetConfiguration(mockFacetConfiguration, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3640,7 +3640,7 @@ describe('ConstructorIO - Catalog', () => {
           networkParameters: { timeout: 20 },
         });
 
-        return expect(catalog.addFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejected;
+        return expect(catalog.addFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -3766,7 +3766,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyFacetConfigurations(
           { facetConfigurations: newFacetConfigurations },
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3787,7 +3787,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.modifyFacetConfigurations(
           { facetConfigurations: newFacetConfigurations },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -3881,7 +3881,7 @@ describe('ConstructorIO - Catalog', () => {
           display_name: 'New Facet Display Name',
           type: 'multiple',
           position: 5,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3895,7 +3895,7 @@ describe('ConstructorIO - Catalog', () => {
           display_name: 'New Facet Display Name',
           type: 'multiple',
           position: 5,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -3985,7 +3985,7 @@ describe('ConstructorIO - Catalog', () => {
           name: mockFacetConfiguration.name,
           display_name: 'New Facet Display Name',
           position: 5,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -3998,7 +3998,7 @@ describe('ConstructorIO - Catalog', () => {
           name: mockFacetConfiguration.name,
           display_name: 'New Facet Display Name',
           position: 5,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -4034,7 +4034,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeFacetConfiguration(
           mockFacetConfiguration,
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4046,7 +4046,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.removeFacetConfiguration(
           mockFacetConfiguration,
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });
@@ -4125,7 +4125,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addFacetOptionConfiguration(
           createMockFacetOptionConfiguration(facetGroupName),
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4136,7 +4136,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.addFacetOptionConfiguration(
           createMockFacetOptionConfiguration(facetGroupName),
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -4227,7 +4227,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrModifyFacetOptionConfigurations({
           facetGroupName: mockFacetOptionConfigurations,
           facetOptionConfigurations: mockFacetOptionConfigurations,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when network request timeout is provided and reached', () => {
@@ -4236,7 +4236,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrModifyFacetOptionConfigurations({
           facetGroupName,
           facetOptionConfigurations: mockFacetOptionConfigurations,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4248,7 +4248,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrModifyFacetOptionConfigurations({
           facetGroupName,
           facetOptionConfigurations: mockFacetOptionConfigurations,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -4312,7 +4312,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.getFacetOptionConfigurations({
           facetGroupName,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4323,7 +4323,7 @@ describe('ConstructorIO - Catalog', () => {
 
         return expect(catalog.getFacetOptionConfigurations({
           facetGroupName,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -4378,7 +4378,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getFacetOptionConfiguration({
           facetGroupName,
           value,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4391,7 +4391,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getFacetOptionConfiguration({
           facetGroupName,
           value,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -4483,7 +4483,7 @@ describe('ConstructorIO - Catalog', () => {
           value: mockFacetOptionConfiguration.value,
           display_name: 'New Facet Option Display Name',
           position: 5,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4497,7 +4497,7 @@ describe('ConstructorIO - Catalog', () => {
           value: mockFacetOptionConfiguration.value,
           display_name: 'New Facet Option Display Name',
           position: 5,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -4588,7 +4588,7 @@ describe('ConstructorIO - Catalog', () => {
           value: mockFacetOptionConfiguration.value,
           display_name: 'New Facet Display Name',
           position: 5,
-        }, { timeout: 10 })).to.eventually.be.rejected;
+        }, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4602,7 +4602,7 @@ describe('ConstructorIO - Catalog', () => {
           value: mockFacetOptionConfiguration.value,
           display_name: 'New Facet Display Name',
           position: 5,
-        })).to.eventually.be.rejected;
+        })).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
 
@@ -4638,7 +4638,7 @@ describe('ConstructorIO - Catalog', () => {
         expect(catalog.removeFacetOptionConfiguration(
           mockFacetOptionConfiguration,
           { timeout: 10 },
-        )).to.eventually.be.rejected;
+        )).to.eventually.be.rejectedWith('The user aborted a request.');
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -4648,7 +4648,7 @@ describe('ConstructorIO - Catalog', () => {
         });
         const mockFacetOptionConfiguration = createMockFacetOptionConfiguration(facetGroupName);
 
-        expect(catalog.removeFacetOptionConfiguration(mockFacetOptionConfiguration)).to.eventually.be.rejected;
+        expect(catalog.removeFacetOptionConfiguration(mockFacetOptionConfiguration)).to.eventually.be.rejectedWith('The user aborted a request.');
       });
     });
   });

--- a/spec/src/modules/catalog.js
+++ b/spec/src/modules/catalog.js
@@ -4227,7 +4227,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrModifyFacetOptionConfigurations({
           facetGroupName: mockFacetOptionConfigurations,
           facetOptionConfigurations: mockFacetOptionConfigurations,
-        })).to.eventually.be.rejectedWith('The user aborted a request.');
+        })).to.eventually.be.rejected;
       });
 
       it('Should be rejected when network request timeout is provided and reached', () => {

--- a/spec/src/modules/catalog.js
+++ b/spec/src/modules/catalog.js
@@ -1585,7 +1585,7 @@ describe('ConstructorIO - Catalog', () => {
         });
 
         return expect(catalog.getOneWaySynonym(
-          { phrase: mockOneWaySynonymPhrase }
+          { phrase: mockOneWaySynonymPhrase },
         )).to.eventually.be.rejected;
       });
     });
@@ -4635,7 +4635,10 @@ describe('ConstructorIO - Catalog', () => {
         const { catalog } = new ConstructorIO(validOptions);
         const mockFacetOptionConfiguration = createMockFacetOptionConfiguration(facetGroupName);
 
-        expect(catalog.removeFacetOptionConfiguration(mockFacetOptionConfiguration, { timeout: 10 })).to.eventually.be.rejected;
+        expect(catalog.removeFacetOptionConfiguration(
+          mockFacetOptionConfiguration,
+          { timeout: 10 },
+        )).to.eventually.be.rejected;
       });
 
       it('Should be rejected when global network request timeout is provided and reached', () => {

--- a/spec/src/modules/catalog.js
+++ b/spec/src/modules/catalog.js
@@ -169,10 +169,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addItem(mockItem)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addItem(createMockItem(), { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addItem(createMockItem())).to.eventually.be.rejected;
       });
     });
 
@@ -244,10 +253,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrUpdateItem(mockItem)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addOrUpdateItem(createMockItem(), { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addOrUpdateItem(createMockItem())).to.eventually.be.rejected;
       });
     });
 
@@ -310,10 +328,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeItem(mockItem)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeItem(mockItem, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeItem(mockItem)).to.eventually.be.rejected;
       });
     });
 
@@ -385,10 +412,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyItem(mockItem)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.modifyItem(mockItem, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.modifyItem(mockItem)).to.eventually.be.rejected;
       });
     });
 
@@ -435,10 +471,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addItemsBatch({ items, section: 'Products' })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addItemsBatch([createMockItem()], { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addItemsBatch([createMockItem()])).to.eventually.be.rejected;
       });
     });
 
@@ -495,10 +540,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrUpdateItemsBatch({ items, section: 'Products' })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addOrUpdateItemsBatch({ items, section: 'Products' }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when network global request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addOrUpdateItemsBatch({ items, section: 'Products' })).to.eventually.be.rejected;
       });
     });
 
@@ -569,10 +623,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeItemsBatch({ items, section: 'Products' })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeItemsBatch({ items, section: 'Products' }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeItemsBatch({ items, section: 'Products' })).to.eventually.be.rejected;
       });
     });
 
@@ -643,10 +706,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getItem({ id: mockItem.id })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getItem({ id: mockItem.id }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getItem({ id: mockItem.id })).to.eventually.be.rejected;
       });
     });
 
@@ -722,10 +794,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getItems({ section: 'Products' })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getItems({ section: 'Products' }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getItems({ section: 'Products' })).to.eventually.be.rejected;
       });
     });
   });
@@ -769,10 +850,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addItemGroup(group)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addItemGroup(createMockItemGroup(), { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addItemGroup(createMockItemGroup())).to.eventually.be.rejected;
       });
     });
 
@@ -818,10 +908,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addItemGroups({ item_groups: groups })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addItemGroups([createMockItemGroup()], { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addItemGroups([createMockItemGroup()])).to.eventually.be.rejected;
       });
     });
 
@@ -893,10 +992,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getItemGroup({ group_id: mockItemGroup.id })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getItemGroup({ group_id: mockItemGroup.id }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getItemGroup({ group_id: mockItemGroup.id })).to.eventually.be.rejected;
       });
     });
 
@@ -954,10 +1062,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getItemGroups()).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getItemGroups({ timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getItemGroups()).to.eventually.be.rejected;
       });
     });
 
@@ -1034,12 +1151,23 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addOrUpdateItemGroups({ item_groups: groups })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addOrUpdateItemGroups(
           { item_groups: groups },
           { timeout: 10 },
+        )).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addOrUpdateItemGroups(
+          { item_groups: groups },
         )).to.eventually.be.rejected;
       });
     });
@@ -1101,10 +1229,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyItemGroup(mockItemGroup)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.modifyItemGroup(mockItemGroup, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.modifyItemGroup(mockItemGroup)).to.eventually.be.rejected;
       });
     });
 
@@ -1166,10 +1303,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeItemGroups()).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeItemGroups({ timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeItemGroups()).to.eventually.be.rejected;
       });
     });
   });
@@ -1234,13 +1380,25 @@ describe('ConstructorIO - Catalog', () => {
         })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addOneWaySynonym({
           phrase: createMockOneWaySynonymPhrase(),
           child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addOneWaySynonym({
+          phrase: createMockOneWaySynonymPhrase(),
+          child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -1315,13 +1473,25 @@ describe('ConstructorIO - Catalog', () => {
         })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.modifyOneWaySynonym({
           phrase: mockOneWaySynonymPhrase,
           child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.modifyOneWaySynonym({
+          phrase: mockOneWaySynonymPhrase,
+          child_phrases: [{ phrase: createMockOneWaySynonymPhrase() }],
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -1399,12 +1569,23 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getOneWaySynonym({ phrase: mockOneWaySynonymPhrase })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getOneWaySynonym(
           { phrase: mockOneWaySynonymPhrase },
           { timeout: 10 },
+        )).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getOneWaySynonym(
+          { phrase: mockOneWaySynonymPhrase }
         )).to.eventually.be.rejected;
       });
     });
@@ -1482,10 +1663,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getOneWaySynonyms()).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getOneWaySynonyms({}, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getOneWaySynonyms({})).to.eventually.be.rejected;
       });
     });
 
@@ -1539,12 +1729,23 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeOneWaySynonym({ phrase: mockOneWaySynonymPhrase })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeOneWaySynonym(
           { phrase: mockOneWaySynonymPhrase },
           { timeout: 10 },
+        )).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeOneWaySynonym(
+          { phrase: mockOneWaySynonymPhrase },
         )).to.eventually.be.rejected;
       });
     });
@@ -1599,10 +1800,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeOneWaySynonyms()).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeOneWaySynonyms({ timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeOneWaySynonyms()).to.eventually.be.rejected;
       });
     });
   });
@@ -1653,12 +1863,23 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addSynonymGroup({ synonyms: [mockSynonym] })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addSynonymGroup(
           { synonyms: [createMockSynonym()] },
           { timeout: 10 },
+        )).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addSynonymGroup(
+          { synonyms: [createMockSynonym()] },
         )).to.eventually.be.rejected;
       });
     });
@@ -1733,13 +1954,25 @@ describe('ConstructorIO - Catalog', () => {
         })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.modifySynonymGroup({
           id: synonymGroupId,
           synonyms: [mockSynonym],
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.modifySynonymGroup({
+          id: synonymGroupId,
+          synonyms: [mockSynonym],
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -1812,10 +2045,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getSynonymGroup({ id: synonymGroupId }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejected;
       });
     });
 
@@ -1889,10 +2131,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getSynonymGroups()).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getSynonymGroups({}, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getSynonymGroups({})).to.eventually.be.rejected;
       });
     });
 
@@ -1957,10 +2208,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeSynonymGroup({ id: synonymGroupId }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeSynonymGroup({ id: synonymGroupId })).to.eventually.be.rejected;
       });
     });
 
@@ -2011,10 +2271,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeSynonymGroups()).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeSynonymGroups({ timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeSynonymGroups()).to.eventually.be.rejected;
       });
     });
   });
@@ -2070,10 +2339,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addRedirectRule(mockRedirectRule)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addRedirectRule(createMockRedirectRule(), { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addRedirectRule(createMockRedirectRule())).to.eventually.be.rejected;
       });
     });
 
@@ -2159,13 +2437,25 @@ describe('ConstructorIO - Catalog', () => {
         })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.updateRedirectRule({
           id: redirectRuleId,
           ...mockRedirectRule,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.updateRedirectRule({
+          id: redirectRuleId,
+          ...mockRedirectRule,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -2252,13 +2542,25 @@ describe('ConstructorIO - Catalog', () => {
         })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.modifyRedirectRule({
           id: redirectRuleId,
           ...mockRedirectRule,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.modifyRedirectRule({
+          id: redirectRuleId,
+          ...mockRedirectRule,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -2335,10 +2637,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getRedirectRule({ id: redirectRuleId })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getRedirectRule({ id: redirectRuleId }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getRedirectRule({ id: redirectRuleId })).to.eventually.be.rejected;
       });
     });
 
@@ -2462,10 +2773,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getRedirectRules()).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getRedirectRules({}, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getRedirectRules({})).to.eventually.be.rejected;
       });
     });
 
@@ -2542,10 +2862,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeRedirectRule({ id: redirectRuleId })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.removeRedirectRule({ id: redirectRuleId }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.removeRedirectRule({ id: redirectRuleId })).to.eventually.be.rejected;
       });
     });
   });
@@ -2734,7 +3063,7 @@ describe('ConstructorIO - Catalog', () => {
         });
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         const data = {
@@ -2743,6 +3072,20 @@ describe('ConstructorIO - Catalog', () => {
         };
 
         return expect(catalog.replaceCatalog(data, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        const data = {
+          items: itemsStream,
+          section: 'Products',
+        };
+
+        return expect(catalog.replaceCatalog(data)).to.eventually.be.rejected;
       });
     });
 
@@ -2895,7 +3238,7 @@ describe('ConstructorIO - Catalog', () => {
         });
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         const data = {
@@ -2904,6 +3247,20 @@ describe('ConstructorIO - Catalog', () => {
         };
 
         return expect(catalog.updateCatalog(data, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        const data = {
+          items: itemsStream,
+          section: 'Products',
+        };
+
+        return expect(catalog.updateCatalog(data)).to.eventually.be.rejected;
       });
     });
 
@@ -3056,7 +3413,7 @@ describe('ConstructorIO - Catalog', () => {
         });
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         const data = {
@@ -3065,6 +3422,20 @@ describe('ConstructorIO - Catalog', () => {
         };
 
         return expect(catalog.patchCatalog(data, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        const data = {
+          items: itemsStream,
+          section: 'Products',
+        };
+
+        return expect(catalog.patchCatalog(data)).to.eventually.be.rejected;
       });
     });
   });
@@ -3136,10 +3507,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addFacetConfiguration(mockFacetConfiguration, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejected;
       });
     });
 
@@ -3190,10 +3570,19 @@ describe('ConstructorIO - Catalog', () => {
         });
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getFacetConfigurations({}, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getFacetConfigurations({})).to.eventually.be.rejected;
       });
     });
 
@@ -3239,10 +3628,19 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.getFacetConfiguration({ name: 'gibberish' })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addFacetConfiguration(mockFacetConfiguration, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejected;
       });
     });
 
@@ -3352,7 +3750,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyFacetConfigurations({ facetConfigurations: badFacetConfigurations })).to.eventually.be.rejected; // eslint-disable-line max-len
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
         const newFacetConfigurations = [
           {
@@ -3368,6 +3766,27 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyFacetConfigurations(
           { facetConfigurations: newFacetConfigurations },
           { timeout: 10 },
+        )).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+        const newFacetConfigurations = [
+          {
+            name: mockFacetConfigurations[0].name,
+            display_name: 'New Facet Display Name',
+          },
+          {
+            name: mockFacetConfigurations[1].name,
+            position: 5,
+          },
+        ];
+
+        return expect(catalog.modifyFacetConfigurations(
+          { facetConfigurations: newFacetConfigurations },
         )).to.eventually.be.rejected;
       });
     });
@@ -3454,7 +3873,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.replaceFacetConfiguration(facetConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.replaceFacetConfiguration({
@@ -3463,6 +3882,20 @@ describe('ConstructorIO - Catalog', () => {
           type: 'multiple',
           position: 5,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.replaceFacetConfiguration({
+          name: mockFacetConfiguration.name,
+          display_name: 'New Facet Display Name',
+          type: 'multiple',
+          position: 5,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -3545,7 +3978,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyFacetConfiguration(facetConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.modifyFacetConfiguration({
@@ -3553,6 +3986,19 @@ describe('ConstructorIO - Catalog', () => {
           display_name: 'New Facet Display Name',
           position: 5,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.modifyFacetConfiguration({
+          name: mockFacetConfiguration.name,
+          display_name: 'New Facet Display Name',
+          position: 5,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -3581,13 +4027,25 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeFacetConfiguration(mockFacetConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
         const mockFacetConfiguration = createMockFacetConfiguration();
 
         return expect(catalog.removeFacetConfiguration(
           mockFacetConfiguration,
           { timeout: 10 },
+        )).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+        const mockFacetConfiguration = createMockFacetConfiguration();
+
+        return expect(catalog.removeFacetConfiguration(
+          mockFacetConfiguration,
         )).to.eventually.be.rejected;
       });
     });
@@ -3661,11 +4119,23 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.addFacetOptionConfiguration(mockFacetOptionConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
+
         return expect(catalog.addFacetOptionConfiguration(
           createMockFacetOptionConfiguration(facetGroupName),
           { timeout: 10 },
+        )).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addFacetOptionConfiguration(
+          createMockFacetOptionConfiguration(facetGroupName),
         )).to.eventually.be.rejected;
       });
     });
@@ -3760,13 +4230,25 @@ describe('ConstructorIO - Catalog', () => {
         })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.addOrModifyFacetOptionConfigurations({
           facetGroupName,
           facetOptionConfigurations: mockFacetOptionConfigurations,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.addOrModifyFacetOptionConfigurations({
+          facetGroupName,
+          facetOptionConfigurations: mockFacetOptionConfigurations,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -3825,12 +4307,23 @@ describe('ConstructorIO - Catalog', () => {
         });
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.getFacetOptionConfigurations({
           facetGroupName,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.getFacetOptionConfigurations({
+          facetGroupName,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -3878,7 +4371,7 @@ describe('ConstructorIO - Catalog', () => {
         })).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
         const { value } = mockFacetOptionConfiguration;
 
@@ -3886,6 +4379,19 @@ describe('ConstructorIO - Catalog', () => {
           facetGroupName,
           value,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+        const { value } = mockFacetOptionConfiguration;
+
+        return expect(catalog.getFacetOptionConfiguration({
+          facetGroupName,
+          value,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -3969,7 +4475,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.replaceFacetOptionConfiguration(facetOptionConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.replaceFacetOptionConfiguration({
@@ -3978,6 +4484,20 @@ describe('ConstructorIO - Catalog', () => {
           display_name: 'New Facet Option Display Name',
           position: 5,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.replaceFacetOptionConfiguration({
+          facetGroupName,
+          value: mockFacetOptionConfiguration.value,
+          display_name: 'New Facet Option Display Name',
+          position: 5,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -4060,7 +4580,7 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.modifyFacetOptionConfiguration(facetOptionConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
 
         return expect(catalog.modifyFacetOptionConfiguration({
@@ -4069,6 +4589,20 @@ describe('ConstructorIO - Catalog', () => {
           display_name: 'New Facet Display Name',
           position: 5,
         }, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
+        });
+
+        return expect(catalog.modifyFacetOptionConfiguration({
+          facetGroupName,
+          value: mockFacetOptionConfiguration.value,
+          display_name: 'New Facet Display Name',
+          position: 5,
+        })).to.eventually.be.rejected;
       });
     });
 
@@ -4097,13 +4631,21 @@ describe('ConstructorIO - Catalog', () => {
         return expect(catalog.removeFacetOptionConfiguration(mockFacetOptionConfiguration)).to.eventually.be.rejected;
       });
 
-      it('Should be rejected when request timeout is provided and reached', () => {
+      it('Should be rejected when network request timeout is provided and reached', () => {
         const { catalog } = new ConstructorIO(validOptions);
         const mockFacetOptionConfiguration = createMockFacetOptionConfiguration(facetGroupName);
 
-        catalog.addFacetOptionConfiguration(mockFacetOptionConfiguration).then(() => {
-          expect(catalog.removeFacetOptionConfiguration(mockFacetOptionConfiguration)).to.eventually.be.rejected;
+        expect(catalog.removeFacetOptionConfiguration(mockFacetOptionConfiguration, { timeout: 10 })).to.eventually.be.rejected;
+      });
+
+      it('Should be rejected when global network request timeout is provided and reached', () => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          networkParameters: { timeout: 20 },
         });
+        const mockFacetOptionConfiguration = createMockFacetOptionConfiguration(facetGroupName);
+
+        expect(catalog.removeFacetOptionConfiguration(mockFacetOptionConfiguration)).to.eventually.be.rejected;
       });
     });
   });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -369,7 +369,7 @@ describe('ConstructorIO - Recommendations', () => {
         { itemIds },
         {},
         { timeout: 10 },
-      )).to.eventually.be.rejected;
+      )).to.eventually.be.rejectedWith('The user aborted a request.');
     });
 
     it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -382,7 +382,7 @@ describe('ConstructorIO - Recommendations', () => {
         podId,
         { itemIds },
         {},
-      )).to.eventually.be.rejected;
+      )).to.eventually.be.rejectedWith('The user aborted a request.');
     });
   });
 });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -361,7 +361,7 @@ describe('ConstructorIO - Recommendations', () => {
       })).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when request timeout is provided and reached', () => {
+    it('Should be rejected when network request timeout is provided and reached', () => {
       const { recommendations } = new ConstructorIO(validOptions);
 
       return expect(recommendations.getRecommendations(
@@ -369,6 +369,19 @@ describe('ConstructorIO - Recommendations', () => {
         { itemIds },
         {},
         { timeout: 10 },
+      )).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when global network request timeout is provided and reached', () => {
+      const { recommendations } = new ConstructorIO({
+        ...validOptions,
+        networkParameters: { timeout: 20 },
+      });
+
+      return expect(recommendations.getRecommendations(
+        podId,
+        { itemIds },
+        {},
       )).to.eventually.be.rejected;
     });
   });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -444,7 +444,7 @@ describe('ConstructorIO - Search', () => {
     it('Should be rejected when network request timeout is provided and reached', () => {
       const { search } = new ConstructorIO(validOptions);
 
-      return expect(search.getSearchResults(query, { section }, {}, { timeout: 10 })).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, { section }, {}, { timeout: 10 })).to.eventually.be.rejectedWith('The user aborted a request.');
     });
 
     it('Should be rejected when global network request timeout is provided and reached', () => {
@@ -453,7 +453,7 @@ describe('ConstructorIO - Search', () => {
         networkParameters: { timeout: 20 },
       });
 
-      return expect(search.getSearchResults(query, { section }, {})).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, { section }, {})).to.eventually.be.rejectedWith('The user aborted a request.');
     });
   });
 });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -446,5 +446,16 @@ describe('ConstructorIO - Search', () => {
 
       return expect(search.getSearchResults(query, { section }, {}, { timeout: 10 })).to.eventually.be.rejected;
     });
+
+    it('Should be rejected when global request timeout is provided and reached', () => {
+      const { search } = new ConstructorIO({
+        ...validOptions,
+        networkParameters: {
+          timeout: 20,
+        },
+      });
+
+      return expect(search.getSearchResults(query, { section }, {})).to.eventually.be.rejected;
+    });
   });
 });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -441,18 +441,16 @@ describe('ConstructorIO - Search', () => {
       return expect(search.getSearchResults(query, { section })).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when request timeout is provided and reached', () => {
+    it('Should be rejected when network request timeout is provided and reached', () => {
       const { search } = new ConstructorIO(validOptions);
 
       return expect(search.getSearchResults(query, { section }, {}, { timeout: 10 })).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when global request timeout is provided and reached', () => {
+    it('Should be rejected when global network request timeout is provided and reached', () => {
       const { search } = new ConstructorIO({
         ...validOptions,
-        networkParameters: {
-          timeout: 20,
-        },
+        networkParameters: { timeout: 20 },
       });
 
       return expect(search.getSearchResults(query, { section }, {})).to.eventually.be.rejected;

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -343,12 +343,23 @@ describe('ConstructorIO - Tracker', () => {
       })).to.equal(true);
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackSessionStart(userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackSessionStart(userParameters)).to.equal(true);
     });
   });
 
@@ -656,12 +667,23 @@ describe('ConstructorIO - Tracker', () => {
       })).to.equal(true);
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackInputFocus(userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackInputFocus(userParameters)).to.equal(true);
     });
   });
 
@@ -1004,12 +1026,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackAutocompleteSelect(term, null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackAutocompleteSelect(term, requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackAutocompleteSelect(term, requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -1345,8 +1378,19 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchSubmit(term, null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackSearchSubmit(term, requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
 
       tracker.on('error', () => { done(); });
 
@@ -1732,7 +1776,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchResultsLoaded(term, null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
@@ -1742,6 +1786,21 @@ describe('ConstructorIO - Tracker', () => {
         requiredParameters,
         userParameters,
         { timeout: 10 },
+      )).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackSearchResultsLoaded(
+        term,
+        requiredParameters,
+        userParameters,
       )).to.equal(true);
     });
   });
@@ -2134,12 +2193,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchResultClick(term, null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackSearchResultClick(term, requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackSearchResultClick(term, requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -2692,12 +2762,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackConversion(term, requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackConversion(term, requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -3065,12 +3146,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackPurchase(null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackPurchase(requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackPurchase(requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -3426,12 +3518,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackRecommendationView(null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackRecommendationView(requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackRecommendationView(requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -3792,12 +3895,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackRecommendationClick(null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackRecommendationClick(requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackRecommendationClick(requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -4170,12 +4284,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackBrowseResultsLoaded(null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackBrowseResultsLoaded(requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackBrowseResultsLoaded(requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -4572,12 +4697,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackBrowseResultClick(null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackBrowseResultClick(requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackBrowseResultClick(requiredParameters, userParameters)).to.equal(true);
     });
   });
 
@@ -4959,12 +5095,23 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackGenericResultClick(null, userParameters)).to.be.an('error');
     });
 
-    it('Should throw an error when request timeout is provided and reached', (done) => {
+    it('Should throw an error when network request timeout is provided and reached', (done) => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       tracker.on('error', () => { done(); });
 
       expect(tracker.trackGenericResultClick(requiredParameters, userParameters, { timeout: 10 })).to.equal(true);
+    });
+
+    it('Should throw an error when global network request timeout is provided and reached', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        networkParameters: { timeout: 20 },
+      });
+
+      tracker.on('error', () => { done(); });
+
+      expect(tracker.trackGenericResultClick(requiredParameters, userParameters)).to.equal(true);
     });
   });
 

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase, no-unneeded-ternary */
+/* eslint-disable camelcase, no-unneeded-ternary, max-len */
 
 // Modules
 const Search = require('./modules/search');
@@ -19,6 +19,8 @@ class ConstructorIO {
    * @param {string} [securityToken] - Constructor security token
    * @param {string} [serviceUrl='https://ac.cnstrc.com'] - API URL endpoint
    * @param {function} [fetch] - If supplied, will be utilized for requests rather than default Fetch API
+   * @param {object} [networkParameters] - Parameters relevant to network requests
+   * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds) - may be overridden within individual method calls
    * @property {object} [search] - Interface to {@link module:search}
    * @property {object} [browse] - Interface to {@link module:browse}
    * @property {object} [autocomplete] - Interface to {@link module:autocomplete}
@@ -35,6 +37,7 @@ class ConstructorIO {
       serviceUrl,
       securityToken,
       fetch,
+      networkParameters,
     } = options;
 
     if (!apiKey || typeof apiKey !== 'string') {
@@ -48,6 +51,7 @@ class ConstructorIO {
       version: version || global.CLIENT_VERSION || `cio-node-${packageVersion}`,
       serviceUrl: serviceUrl || 'https://ac.cnstrc.com',
       fetch,
+      networkParameters: networkParameters || {},
     };
 
     // Expose global modules

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -142,7 +142,7 @@ class Autocomplete {
       headers['User-Agent'] = userParameters.userAgent;
     }
 
-    // Handle timeout if specified
+    // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -143,9 +143,7 @@ class Autocomplete {
     }
 
     // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {
       if (response.ok) {

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -219,9 +219,7 @@ class Browse {
     }
 
     // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {
       if (response.ok) {
@@ -291,9 +289,7 @@ class Browse {
     }
 
     // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal })
       .then((response) => {
@@ -351,9 +347,7 @@ class Browse {
     const requestUrl = `${serviceUrl}/browse/groups?${queryString}`;
 
     // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {
       if (response.ok) {
@@ -408,9 +402,7 @@ class Browse {
     }
 
     // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       headers: helpers.createAuthHeader(this.options),

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -218,7 +218,7 @@ class Browse {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
+    // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {
@@ -288,7 +288,7 @@ class Browse {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
+    // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal })
@@ -346,7 +346,7 @@ class Browse {
     const queryString = qs.stringify(queryParams, { indices: false });
     const requestUrl = `${serviceUrl}/browse/groups?${queryString}`;
 
-    // Handle timeout if specified
+    // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {
@@ -401,7 +401,7 @@ class Browse {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
+    // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -162,10 +162,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -218,10 +216,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -265,10 +261,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -322,10 +316,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -368,10 +360,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -414,10 +404,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -460,10 +448,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -515,10 +501,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -581,10 +565,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -628,10 +610,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -673,10 +653,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -718,10 +696,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -760,10 +736,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -804,10 +778,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PATCH',
@@ -853,10 +825,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -896,10 +866,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -939,10 +907,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -986,10 +952,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -1033,10 +997,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -1093,10 +1055,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -1138,10 +1098,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -1180,10 +1138,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -1224,10 +1180,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -1271,10 +1225,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -1316,10 +1268,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -1375,10 +1325,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -1418,10 +1366,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -1457,10 +1403,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -1503,10 +1447,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -1555,10 +1497,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -1607,10 +1547,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PATCH',
@@ -1652,10 +1590,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -1721,10 +1657,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -1762,10 +1696,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -1804,10 +1736,8 @@ class Catalog {
       const { queryParams, formData } = await createQueryParamsAndFormData(parameters);
       const requestUrl = createCatalogUrl('catalog', this.options, queryParams);
 
-      // Handle timeout if specified
-      if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-        setTimeout(() => controller.abort(), networkParameters.timeout);
-      }
+      // Handle network timeout if specified
+      helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
       const response = await fetch(requestUrl, {
         method: 'PUT',
@@ -1850,10 +1780,8 @@ class Catalog {
       const { queryParams, formData } = await createQueryParamsAndFormData(parameters);
       const requestUrl = createCatalogUrl('catalog', this.options, queryParams);
 
-      // Handle timeout if specified
-      if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-        setTimeout(() => controller.abort(), networkParameters.timeout);
-      }
+      // Handle network timeout if specified
+      helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
       const response = await fetch(requestUrl, {
         method: 'PATCH',
@@ -1896,10 +1824,8 @@ class Catalog {
       const { queryParams, formData } = await createQueryParamsAndFormData(parameters);
       const requestUrl = createCatalogUrl('catalog', this.options, { ...queryParams, patch_delta: true });
 
-      // Handle timeout if specified
-      if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-        setTimeout(() => controller.abort(), networkParameters.timeout);
-      }
+      // Handle network timeout if specified
+      helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
       const response = await fetch(requestUrl, {
         method: 'PATCH',
@@ -1961,10 +1887,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -2011,10 +1935,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -2060,10 +1982,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -2108,10 +2028,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PATCH',
@@ -2175,10 +2093,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -2240,10 +2156,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PATCH',
@@ -2292,10 +2206,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',
@@ -2346,10 +2258,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'POST',
@@ -2397,10 +2307,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PATCH',
@@ -2449,10 +2357,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -2499,10 +2405,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'GET',
@@ -2553,10 +2457,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PUT',
@@ -2608,10 +2510,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'PATCH',
@@ -2659,10 +2559,8 @@ class Catalog {
       return Promise.reject(e);
     }
 
-    // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, {
       method: 'DELETE',

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -141,9 +141,7 @@ class Recommendations {
     }
 
     // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {
       if (response.ok) {

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -140,7 +140,7 @@ class Recommendations {
       headers['User-Agent'] = userParameters.userAgent;
     }
 
-    // Handle timeout if specified
+    // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -181,9 +181,7 @@ class Search {
     }
 
     // Handle timeout if specified
-    if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-      setTimeout(() => controller.abort(), networkParameters.timeout);
-    }
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {
       if (response.ok) {

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -180,7 +180,7 @@ class Search {
       headers['User-Agent'] = userParameters.userAgent;
     }
 
-    // Handle timeout if specified
+    // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
     return fetch(requestUrl, { headers, signal }).then((response) => {

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -111,10 +111,8 @@ function send(url, userParameters, networkParameters, method = 'GET', body) { //
     }
   }
 
-  // Handle timeout if specified
-  if (networkParameters.timeout && typeof networkParameters.timeout === 'number') {
-    setTimeout(() => controller.abort(), networkParameters.timeout);
-  }
+  // Handle network timeout if specified
+  helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
   if (method === 'GET') {
     request = fetch(url, { headers, signal });

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -50,6 +50,16 @@ const utils = {
 
     return { Authorization: `Basic ${Buffer.from(`${apiToken}:`).toString('base64')}` };
   },
+
+  // Abort network request based on supplied timeout interval (in milliseconds)
+  // - method call parameter takes precedence over global options parameter
+  applyNetworkTimeout: (options = {}, networkParameters = {}, controller) => {
+    const timeout = options.networkParameters.timeout || networkParameters.timeout;
+
+    if (typeof timeout === 'number') {
+      setTimeout(() => controller.abort(), timeout);
+    }
+  },
 };
 
 module.exports = utils;


### PR DESCRIPTION
- Ensure reason for rejection is as expected in tests
- Add ability to specify network timeout on client instantiation (can be overridden on each method)
- Sub out timeout functionality to method (thanks @esezen)
- Add more tests, test improvements