### PR TITLE
Update tracking documentation examples to have consistent spacing.

### DIFF
--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -243,8 +243,8 @@ class Tracker {
    * @description User focused on search input element
    * @example
    * constructorio.tracker.trackInputFocus({
-   *  sessionId: 1,
-   *  clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     sessionId: 1,
+   *     clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
    * });
    */
   trackInputFocus(userParameters, networkParameters = {}) {
@@ -290,18 +290,18 @@ class Tracker {
    * @description User selected (clicked, or navigated to via keyboard) a result that appeared within autocomplete
    * @example
    * constructorio.tracker.trackAutocompleteSelect(
-   *  'T-Shirt',
-   *  {
-   *   original_query: 'Shirt',
-   *   section: 'Products',
-   *   tr: 'click',
-   *   group_id: '88JU230',
-   *   display_name: 'apparel',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     'T-Shirt',
+   *      {
+   *          original_query: 'Shirt',
+   *          section: 'Products',
+   *          tr: 'click',
+   *          group_id: '88JU230',
+   *          display_name: 'apparel',
+   *      },
+   *      {
+   *          sessionId: 1,
+   *          clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *      },
    * );
    */
   trackAutocompleteSelect(term, parameters, userParameters, networkParameters = {}) {
@@ -383,16 +383,16 @@ class Tracker {
    * @description User submitted a search (pressing enter within input element, or clicking submit element)
    * @example
    * constructorio.tracker.trackSearchSubmit(
-   *  'T-Shirt',
-   *  {
-   *   original_query: 'Shirt',
-   *   group_id: '88JU230',
-   *   display_name: 'apparel',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     'T-Shirt',
+   *     {
+   *         original_query: 'Shirt',
+   *         group_id: '88JU230',
+   *         display_name: 'apparel',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackSearchSubmit(term, parameters, userParameters, networkParameters = {}) {
@@ -458,15 +458,15 @@ class Tracker {
    * @description User loaded a search product listing page
    * @example
    * constructorio.tracker.trackSearchResultsLoaded(
-   *  'T-Shirt',
-   *  {
-   *   num_results: 167,
-   *   item_ids: ['KMH876', 'KMH140', 'KMH437'],
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     'T-Shirt',
+   *     {
+   *         num_results: 167,
+   *         item_ids: ['KMH876', 'KMH140', 'KMH437'],
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackSearchResultsLoaded(term, parameters, userParameters, networkParameters = {}) {
@@ -533,16 +533,16 @@ class Tracker {
    * @description User clicked a result that appeared within a search product listing page
    * @example
    * constructorio.tracker.trackSearchResultClick(
-   *  'T-Shirt',
-   *  {
-   *   item_name: 'Red T-Shirt',
-   *   item_id: 'KMH876',
-   *   result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     'T-Shirt',
+   *     {
+   *         item_name: 'Red T-Shirt',
+   *         item_id: 'KMH876',
+   *         result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackSearchResultClick(term, parameters, userParameters, networkParameters = {}) {
@@ -626,20 +626,20 @@ class Tracker {
    * @description User performed an action indicating interest in an item (add to cart, add to wishlist, etc.)
    * @example
    * constructorio.tracker.trackConversion(
-   *  'T-Shirt',
-   *  {
-   *   item_id: 'KMH876',
-   *   revenue: 12.00,
-   *   item_name: 'Red T-Shirt',
-   *   variation_id: 'KMH879-7632',
-   *   type: 'like',
-   *   result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
-   *   section: 'Products',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     'T-Shirt',
+   *     {
+   *         item_id: 'KMH876',
+   *         revenue: 12.00,
+   *         item_name: 'Red T-Shirt',
+   *         variation_id: 'KMH879-7632',
+   *         type: 'like',
+   *         result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
+   *         section: 'Products',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackConversion(term, parameters, userParameters, networkParameters = {}) {
@@ -750,16 +750,16 @@ class Tracker {
    * @description User completed an order (usually fired on order confirmation page)
    * @example
    * constructorio.tracker.trackPurchase(
-   *  {
-   *   items: [{ item_id: 'KMH876' }, { item_id: 'KMH140' }],
-   *   revenue: 12.00,
-   *   order_id: 'OUNXBG2HMA',
-   *   section: 'Products',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     {
+   *         items: [{ item_id: 'KMH876' }, { item_id: 'KMH140' }],
+   *         revenue: 12.00,
+   *         order_id: 'OUNXBG2HMA',
+   *         section: 'Products',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackPurchase(parameters, userParameters, networkParameters = {}) {
@@ -836,18 +836,18 @@ class Tracker {
    * @description User clicked a result that appeared within a search product listing page
    * @example
    * constructorio.tracker.trackRecommendationView(
-   *  {
-   *   result_count: 22,
-   *   result_page: 2,
-   *   result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
-   *   url: 'https://demo.constructor.io/sandbox/farmstand',
-   *   pod_id: '019927c2-f955-4020',
-   *   num_results_viewed: 3,
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     {
+   *         result_count: 22,
+   *         result_page: 2,
+   *         result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
+   *         url: 'https://demo.constructor.io/sandbox/farmstand',
+   *         pod_id: '019927c2-f955-4020',
+   *         num_results_viewed: 3,
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackRecommendationView(parameters, userParameters, networkParameters = {}) {
@@ -945,21 +945,21 @@ class Tracker {
    * @description User clicked an item that appeared within a list of recommended results
    * @example
    * constructorio.tracker.trackRecommendationClick(
-   *  {
-   *   variation_id: 'KMH879-7632',
-   *   result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
-   *   result_count: 22,
-   *   result_page: 2,
-   *   result_position_on_page: 2,
-   *   num_results_per_page: 12,
-   *   pod_id: '019927c2-f955-4020',
-   *   strategy_id: 'complimentary',
-   *   item_id: 'KMH876',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     {
+   *         variation_id: 'KMH879-7632',
+   *         result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
+   *         result_count: 22,
+   *         result_page: 2,
+   *         result_position_on_page: 2,
+   *         num_results_per_page: 12,
+   *         pod_id: '019927c2-f955-4020',
+   *         strategy_id: 'complimentary',
+   *         item_id: 'KMH876',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackRecommendationClick(parameters, userParameters, networkParameters = {}) {
@@ -1074,22 +1074,22 @@ class Tracker {
    * @description User loaded a browse product listing page
    * @example
    * constructorio.tracker.trackBrowseResultsLoaded(
-   *  {
-   *   result_count: 22,
-   *   result_page: 2,
-   *   result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
-   *   selected_filters: [ 'brand', 'color' ],
-   *   sort_order: 'ascending',
-   *   sort_by: 'price',
-   *   items: [{ item_id: 'KMH876' }, { item_id: 'KMH140' }],
-   *   url: 'https://demo.constructor.io/sandbox/farmstand',
-   *   filter_name: 'brand',
-   *   filter_value: 'XYZ',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     {
+   *         result_count: 22,
+   *         result_page: 2,
+   *         result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
+   *         selected_filters: [ 'brand', 'color' ],
+   *         sort_order: 'ascending',
+   *         sort_by: 'price',
+   *         items: [{ item_id: 'KMH876' }, { item_id: 'KMH140' }],
+   *         url: 'https://demo.constructor.io/sandbox/farmstand',
+   *         filter_name: 'brand',
+   *         filter_value: 'XYZ',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackBrowseResultsLoaded(parameters, userParameters, networkParameters = {}) {
@@ -1209,22 +1209,22 @@ class Tracker {
    * @description User clicked a result that appeared within a browse product listing page
    * @example
    * constructorio.tracker.trackBrowseResultClick(
-   *  {
-   *   variation_id: 'KMH879-7632',
-   *   result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
-   *   result_count: 22,
-   *   result_page: 2,
-   *   result_position_on_page: 2,
-   *   num_results_per_page: 12,
-   *   selected_filters: [ 'brand', 'color' ],
-   *   filter_name: 'brand',
-   *   filter_value: 'XYZ',
-   *   item_id: 'KMH876',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     {
+   *         variation_id: 'KMH879-7632',
+   *         result_id: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
+   *         result_count: 22,
+   *         result_page: 2,
+   *         result_position_on_page: 2,
+   *         num_results_per_page: 12,
+   *         selected_filters: [ 'brand', 'color' ],
+   *         filter_name: 'brand',
+   *         filter_value: 'XYZ',
+   *         item_id: 'KMH876',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackBrowseResultClick(parameters, userParameters, networkParameters = {}) {
@@ -1337,15 +1337,15 @@ class Tracker {
    * @description User clicked a result that appeared within a browse product listing page
    * @example
    * constructorio.tracker.trackGenericResultClick(
-   *  {
-   *   item_id: 'KMH876',
-   *   item_name: 'Red T-Shirt',
-   *   variation_id: 'KMH879-7632',
-   *  },
-   *  {
-   *   sessionId: 1,
-   *   clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
-   *  },
+   *     {
+   *         item_id: 'KMH876',
+   *         item_name: 'Red T-Shirt',
+   *         variation_id: 'KMH879-7632',
+   *     },
+   *     {
+   *         sessionId: 1,
+   *         clientId: '7a43138f-c87b-29c0-872d-65b00ed0e392',
+   *     },
    * );
    */
   trackGenericResultClick(parameters, userParameters, networkParameters = {}) {
@@ -1404,7 +1404,7 @@ class Tracker {
    * @see https://nodejs.org/api/events.html#events_error_events
    * @example
    * constructorio.tracker.on('error', (data) => {
-   *   // Handle tracking error
+   *     // Handle tracking error
    * });
    */
   on(messageType, callback) {


### PR DESCRIPTION
Pedantic, but in the name of consistency... all of our other documentation examples use 4 spaces.