### PR TITLE
[CSL 1971] Add Support for pre filter expresssions

### DIFF
--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -483,6 +483,45 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should return a response with a valid filterName, filterValue, and preFilterExpression', (done) => {
+      const preFilterExpression = {
+        or: [
+          {
+            and: [
+              { name: 'group_id', value: 'BrandXY' },
+              { name: 'Color', value: 'red' },
+            ],
+          },
+          {
+            and: [
+              { name: 'Color', value: 'blue' },
+              { name: 'Brand', value: 'XYZ' },
+            ],
+          },
+        ],
+      };
+      const { browse } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseResults('group_id', 'All', { preFilterExpression }).then((res) => {
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(res.request).to.have.property('browse_filter_name');
+        expect(res.request).to.have.property('browse_filter_value');
+        expect(res.request.browse_filter_name).to.equal('group_id');
+        expect(res.request.browse_filter_value).to.equal('All');
+        expect(JSON.stringify(res.request.pre_filter_expression)).to.eql(JSON.stringify(preFilterExpression));
+        expect(res.response).to.have.property('results').to.be.an('array');
+        expect(res.response.results.length).to.be.eql(2);
+        expect(res.response.results[0].data.facets.find((facet) => facet.name === 'Color').values).to.be.an('array').that.include('red');
+        expect(res.response.results[1].data.facets.find((facet) => facet.name === 'Color').values).to.be.an('array').that.include('blue');
+        done();
+      });
+    });
+
     it('Should properly encode path parameters', (done) => {
       const specialCharacters = '+[]&';
       const filterNameSpecialCharacters = `name ${specialCharacters}`;

--- a/spec/src/modules/catalog/catalog-files.js
+++ b/spec/src/modules/catalog/catalog-files.js
@@ -210,6 +210,7 @@ describe('ConstructorIO - Catalog', () => {
           variations: variationsBuffer,
           item_groups: itemGroupsBuffer,
           section: 'Products',
+          force: true,
         };
 
         catalog.replaceCatalog(data).then((res) => {

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -443,6 +443,41 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
+    it('Should return a response with a valid query, section and preFilterExpression', (done) => {
+      const preFilterExpression = {
+        or: [
+          {
+            and: [
+              { name: 'group_id', value: 'BrandXY' },
+              { name: 'Color', value: 'red' },
+            ],
+          },
+          {
+            and: [
+              { name: 'Color', value: 'blue' },
+              { name: 'Brand', value: 'XYZ' },
+            ],
+          },
+        ],
+      };
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      search.getSearchResults('item', { preFilterExpression }, {}).then((res) => {
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(JSON.stringify(res.request.pre_filter_expression)).to.eql(JSON.stringify(preFilterExpression));
+        expect(res.response).to.have.property('results').to.be.an('array');
+        expect(res.response.results.length).to.be.eql(2);
+        expect(res.response.results[0].data.facets.find((facet) => facet.name === 'Color').values).to.be.an('array').that.include('red');
+        expect(res.response.results[1].data.facets.find((facet) => facet.name === 'Color').values).to.be.an('array').that.include('blue');
+        done();
+      });
+    });
+
     it('Should properly encode path parameter', (done) => {
       const specialCharacters = '+[]&';
       const querySpecialCharacters = `apple ${specialCharacters}`;

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -36,6 +36,7 @@ function createQueryParams(parameters, userParameters, options) {
       hiddenFields,
       hiddenFacets,
       variationsMap,
+      preFilterExpression,
     } = parameters;
 
     // Pull page from parameters
@@ -98,6 +99,11 @@ function createQueryParams(parameters, userParameters, options) {
     // Pull variations map from parameters
     if (variationsMap) {
       queryParams.variations_map = JSON.stringify(variationsMap);
+    }
+
+    // Pull filter expression from parameters
+    if (preFilterExpression) {
+      queryParams.pre_filter_expression = JSON.stringify(preFilterExpression);
     }
   }
 
@@ -245,6 +251,7 @@ class Browse {
    * @param {string[]} [parameters.hiddenFields] - Hidden metadata fields to return
    * @param {string[]} [parameters.hiddenFacets] - Hidden facet fields to return
    * @param {object} [parameters.variationsMap] - The variations map object to aggregate variations. Please refer to https://docs.constructor.io/rest_api/variations_mapping for details
+   * @param {object} [parameters.preFilterExpression] - Faceting expression to scope search results. Please refer to https://docs.constructor.io/rest_api/collections/#add-items-dynamically for details
    * @param {object} [userParameters] - Parameters relevant to the user request
    * @param {number} [userParameters.sessionId] - Session ID, utilized to personalize results
    * @param {number} [userParameters.clientId] - Client ID, utilized to personalize results

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -60,6 +60,7 @@ function createSearchUrl(query, parameters, userParameters, options) {
       hiddenFields,
       hiddenFacets,
       variationsMap,
+      preFilterExpression,
     } = parameters;
 
     // Pull page from parameters
@@ -124,6 +125,11 @@ function createSearchUrl(query, parameters, userParameters, options) {
     if (variationsMap) {
       queryParams.variations_map = JSON.stringify(variationsMap);
     }
+
+    // Pull filter expression from parameters
+    if (preFilterExpression) {
+      queryParams.pre_filter_expression = JSON.stringify(preFilterExpression);
+    }
   }
 
   queryParams._dt = Date.now();
@@ -163,6 +169,7 @@ class Search {
    * @param {string[]} [parameters.hiddenFields] - Hidden metadata fields to return
    * @param {string[]} [parameters.hiddenFacets] - Hidden facet fields to return
    * @param {object} [parameters.variationsMap] - The variations map object to aggregate variations. Please refer to https://docs.constructor.io/rest_api/variations_mapping for details
+   * @param {object} [parameters.preFilterExpression] - Faceting expression to scope search results. Please refer to https://docs.constructor.io/rest_api/collections/#add-items-dynamically for details
    * @param {object} [userParameters] - Parameters relevant to the user request
    * @param {number} [userParameters.sessionId] - Session ID, utilized to personalize results
    * @param {number} [userParameters.clientId] - Client ID, utilized to personalize results


### PR DESCRIPTION
### Updates:
* Add support for pre filter expressions
* There's a PR in the integration examples repo that I used to update the products in the Request Test index to test the expressions
    * https://github.com/Constructor-io/integration-examples/pull/3
    * Might not be super necessary, but good to keep things consistent
    