### PR TITLE
[CSL-2397] Add support for searchability configurations

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -40,5 +40,6 @@
     "searchandized",
     "searchandizing",
     "patchdelta",
+    "searchabilities"
   ]
 }

--- a/spec/src/modules/catalog/catalog-searchabilities.js
+++ b/spec/src/modules/catalog/catalog-searchabilities.js
@@ -1,0 +1,144 @@
+/* eslint-disable no-unused-expressions, import/no-unresolved, no-restricted-syntax, max-nested-callbacks */
+const dotenv = require('dotenv');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const ConstructorIO = require('../../../../test/constructorio'); // eslint-disable-line import/extensions
+const helpers = require('../../../mocha.helpers');
+
+const nodeFetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+dotenv.config();
+
+const sendTimeout = 300;
+const testApiKey = process.env.TEST_CATALOG_API_KEY;
+const testApiToken = process.env.TEST_API_TOKEN;
+const validOptions = {
+  apiKey: testApiKey,
+  apiToken: testApiToken,
+};
+const skipNetworkTimeoutTests = process.env.SKIP_NETWORK_TIMEOUT_TESTS === 'true';
+
+describe('ConstructorIO - Catalog', () => {
+  const clientVersion = 'cio-mocha';
+  let fetchSpy;
+
+  beforeEach(() => {
+    global.CLIENT_VERSION = clientVersion;
+    fetchSpy = sinon.spy(nodeFetch);
+  });
+
+  afterEach((done) => {
+    delete global.CLIENT_VERSION;
+
+    fetchSpy = null;
+
+    // Add throttling between requests to avoid rate limiting
+    setTimeout(done, sendTimeout);
+  });
+
+  describe('Searchabilities', () => {
+    describe('retrieveSearchabilities', () => {
+      it('Should return a response when retrieving searchabilities', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+
+        catalog.retrieveSearchabilities().then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(res).to.have.property('searchabilities').to.be.an('array').length.gte(1);
+          expect(fetchSpy).to.have.been.called;
+          expect(requestedUrlParams).to.have.property('key');
+          done();
+        });
+      });
+
+      it('Should return a response when retrieving searchabilities with pagination parameters', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+
+        catalog.retrieveSearchabilities({ numResultsPerPage: 1, page: 1 }).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(res).to.have.property('searchabilities').to.be.an('array').length(1);
+          expect(fetchSpy).to.have.been.called;
+          expect(requestedUrlParams).to.have.property('key');
+          expect(requestedUrlParams).to.have.property('num_results_per_page').to.equal('1');
+          expect(requestedUrlParams).to.have.property('page').to.equal('1');
+          done();
+        });
+      });
+
+      it('Should return a response when retrieving searchabilities with name parameter', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+
+        catalog.retrieveSearchabilities({ name: 'groups' }).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(res).to.have.property('searchabilities').to.be.an('array').length(1);
+          expect(fetchSpy).to.have.been.called;
+          expect(requestedUrlParams).to.have.property('key');
+          expect(requestedUrlParams).to.have.property('filters').to.have.property('name').to.equal('groups');
+          done();
+        });
+      });
+
+      it('Should return a response when retrieving searchabilities with additional parameters', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+        const additionalParameters = {
+          offset: 1,
+          numResultsPerPage: 50,
+          filters: { exact_searchable: true },
+          searchable: true,
+          sortBy: 'name',
+          sortOrder: 'descending',
+        };
+
+        catalog.retrieveSearchabilities(additionalParameters).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(res).to.have.property('searchabilities').to.be.an('array').length(1);
+          expect(fetchSpy).to.have.been.called;
+          expect(requestedUrlParams).to.have.property('key');
+          expect(requestedUrlParams).to.have.property('offset').to.equal(String(additionalParameters.offset));
+          expect(requestedUrlParams).to.have.property('num_results_per_page').to.equal(String(additionalParameters.numResultsPerPage));
+          expect(requestedUrlParams).to.have.property('searchable').to.equal(String(additionalParameters.searchable));
+          expect(requestedUrlParams).to.have.property('sort_by').to.equal(additionalParameters.sortBy);
+          expect(requestedUrlParams).to.have.property('sort_order').to.equal(additionalParameters.sortOrder);
+          expect(requestedUrlParams).to.have.property('filters').to.have.property('exact_searchable').to.equal(String(additionalParameters.filters.exact_searchable));
+          done();
+        });
+      });
+
+      if (!skipNetworkTimeoutTests) {
+        it('Should be rejected when network request timeout is provided and reached', () => {
+          const { catalog } = new ConstructorIO(validOptions);
+
+          return expect(catalog.retrieveSearchabilities({}, { timeout: 10 })).to.eventually.be.rejectedWith('The operation was aborted.');
+        });
+
+        it('Should be rejected when global network request timeout is provided and reached', () => {
+          const { catalog } = new ConstructorIO({
+            ...validOptions,
+            networkParameters: { timeout: 20 },
+          });
+
+          return expect(catalog.retrieveSearchabilities()).to.eventually.be.rejectedWith('The operation was aborted.');
+        });
+      }
+    });
+  });
+});

--- a/spec/src/modules/catalog/catalog-searchabilities.js
+++ b/spec/src/modules/catalog/catalog-searchabilities.js
@@ -101,7 +101,7 @@ describe('ConstructorIO - Catalog', () => {
         const additionalParameters = {
           offset: 1,
           numResultsPerPage: 50,
-          filters: { exact_searchable: true },
+          filters: { exactSearchable: true },
           searchable: true,
           sortBy: 'name',
           sortOrder: 'descending',
@@ -118,7 +118,7 @@ describe('ConstructorIO - Catalog', () => {
           expect(requestedUrlParams).to.have.property('searchable').to.equal(String(additionalParameters.searchable));
           expect(requestedUrlParams).to.have.property('sort_by').to.equal(additionalParameters.sortBy);
           expect(requestedUrlParams).to.have.property('sort_order').to.equal(additionalParameters.sortOrder);
-          expect(requestedUrlParams).to.have.property('filters').to.have.property('exact_searchable').to.equal(String(additionalParameters.filters.exact_searchable));
+          expect(requestedUrlParams).to.have.property('filters').to.have.property('exact_searchable').to.equal(String(additionalParameters.filters.exactSearchable));
           done();
         });
       });

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -3317,7 +3317,7 @@ class Catalog {
    * Retrieve metadata searchabilities
    *
    * @function retrieveSearchabilities
-   * @param {object} parameters - Additional parameters for retrieving metadata searchabilities
+   * @param {object} [parameters] - Additional parameters for retrieving metadata searchabilities
    * @param {string} [parameters.name] - Name of metadata searchability. Providing this field would filter the results based on name
    * @param {number} [parameters.page] - The page number of the results. Can't be used together with 'offset'
    * @param {number} [parameters.offset] - The number of results to skip from the beginning. Can't be used together with 'page'
@@ -3420,7 +3420,7 @@ class Catalog {
    *
    * @function patchSearchabilities
    * @param {object} parameters - Additional parameters for patching metadata searchabilities
-   * @param {object[]} [parameters.searchabilities] - Array of searchabilities. Additional information about the searchabilities schema can be found [here]{@link https://docs.constructor.io/rest_api/searchabilities/#patch-searchabilities}
+   * @param {object[]} parameters.searchabilities - Array of searchabilities. Additional information about the searchabilities schema can be found [here]{@link https://docs.constructor.io/rest_api/searchabilities/#patch-searchabilities}
    * @param {string} [parameters.section] - The section in which the searchability is defined. Default value is Products
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -3323,7 +3323,7 @@ class Catalog {
    * @param {number} [parameters.offset] - The number of results to skip from the beginning. Can't be used together with 'page'
    * @param {number} [parameters.numResultsPerPage] - The number of searchability configurations to return. Defaults to 100
    * @param {object} [parameters.filters] - Filters the results based on name, exactSearchable or fuzzySearchable
-   * @param {boolean} [parameters.searchable] - Retrieve only results which are either exact_searchable or fuzzy_searchable
+   * @param {boolean} [parameters.searchable] - Retrieve only results which are either exactSearchable or fuzzySearchable
    * @param {string} [parameters.sortBy] - The criteria by which searchability configurations should be sorted. Defaults to no sorting. Valid criteria is name
    * @param {string} [parameters.sortOrder] - Either descending or ascending. The sort order by which searchability configurations should be sorted. Only valid in conjunction with sortBy
    * @param {string} [parameters.section] - The section in which the searchability is defined. Default value is Products
@@ -3335,7 +3335,7 @@ class Catalog {
    * constructorio.catalog.retrieveSearchabilities({
    *     page: 2,
    *     numResultsPerPage: 50,
-   *     filters: { exact_searchable: true }
+   *     filters: { exactSearchable: true }
    * });
    */
   retrieveSearchabilities(parameters = {}, networkParameters = {}) {

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -3414,6 +3414,68 @@ class Catalog {
       return helpers.throwHttpErrorFromResponse(new Error(), response);
     });
   }
+
+  /**
+   * Patch metadata searchabilities
+   *
+   * @function patchSearchabilities
+   * @param {object} parameters - Additional parameters for patching metadata searchabilities
+   * @param {object[]} [parameters.searchabilities] - Array of searchabilities. Additional information about the searchabilities schema can be found [here]{@link https://docs.constructor.io/rest_api/searchabilities/#patch-searchabilities}
+   * @param {string} [parameters.section] - The section in which the searchability is defined. Default value is Products
+   * @param {object} [networkParameters] - Parameters relevant to the network request
+   * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
+   * @returns {Promise}
+   * @see https://docs.constructor.io/rest_api/searchabilities/#patch-searchabilities
+   * @example
+   * constructorio.catalog.patchSearchabilities({
+   *   searchabilities: [
+   *     {
+   *       name: 'style_id',
+   *       exactSearchable: true,
+   *     },
+   *     {
+   *       name: 'keywords',
+   *       fuzzySearchable: true,
+   *     },
+   *   ],
+   * });
+   */
+  patchSearchabilities(parameters = {}, networkParameters = {}) {
+    let requestUrl;
+    const { fetch } = this.options;
+    const controller = new AbortController();
+    const { signal } = controller;
+    const { searchabilities: searchabilitiesRaw, section = 'Products' } = parameters;
+    const searchabilities = searchabilitiesRaw?.map((config) => toSnakeCaseKeys(config));
+    const additionalQueryParams = {
+      section,
+    };
+
+    try {
+      requestUrl = createCatalogUrl('searchabilities', this.options, additionalQueryParams);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
+
+    return fetch(requestUrl, {
+      method: 'PATCH',
+      body: JSON.stringify({ searchabilities }),
+      headers: {
+        'Content-Type': 'application/json',
+        ...helpers.createAuthHeader(this.options),
+      },
+      signal,
+    }).then((response) => {
+      if (response.ok) {
+        return response.json();
+      }
+
+      return helpers.throwHttpErrorFromResponse(new Error(), response);
+    });
+  }
 }
 
 module.exports = Catalog;

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -3322,7 +3322,7 @@ class Catalog {
    * @param {number} [parameters.page] - The page number of the results. Can't be used together with 'offset'
    * @param {number} [parameters.offset] - The number of results to skip from the beginning. Can't be used together with 'page'
    * @param {number} [parameters.numResultsPerPage] - The number of searchability configurations to return. Defaults to 100
-   * @param {object} [parameters.filters] - Filters the results based on name, exact_searchable or fuzzy_searchable
+   * @param {object} [parameters.filters] - Filters the results based on name, exactSearchable or fuzzySearchable
    * @param {boolean} [parameters.searchable] - Retrieve only results which are either exact_searchable or fuzzy_searchable
    * @param {string} [parameters.sortBy] - The criteria by which searchability configurations should be sorted. Defaults to no sorting. Valid criteria is name
    * @param {string} [parameters.sortOrder] - Either descending or ascending. The sort order by which searchability configurations should be sorted. Only valid in conjunction with sortBy
@@ -3359,7 +3359,7 @@ class Catalog {
     }
 
     if (filters) {
-      additionalQueryParams.filters = filters;
+      additionalQueryParams.filters = toSnakeCaseKeys(filters);
     }
 
     if (searchable) {

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -3312,6 +3312,108 @@ class Catalog {
       return helpers.throwHttpErrorFromResponse(new Error(), response);
     });
   }
+
+  /**
+   * Retrieve metadata searchabilities
+   *
+   * @function retrieveSearchabilities
+   * @param {object} parameters - Additional parameters for retrieving metadata searchabilities
+   * @param {string} [parameters.name] - Name of metadata searchability. Providing this field would filter the results based on name
+   * @param {number} [parameters.page] - The page number of the results. Can't be used together with 'offset'
+   * @param {number} [parameters.offset] - The number of results to skip from the beginning. Can't be used together with 'page'
+   * @param {number} [parameters.numResultsPerPage] - The number of searchability configurations to return. Defaults to 100
+   * @param {object} [parameters.filters] - Filters the results based on name, exact_searchable or fuzzy_searchable
+   * @param {boolean} [parameters.searchable] - Retrieve only results which are either exact_searchable or fuzzy_searchable
+   * @param {string} [parameters.sortBy] - The criteria by which searchability configurations should be sorted. Defaults to no sorting. Valid criteria is name
+   * @param {string} [parameters.sortOrder] - Either descending or ascending. The sort order by which searchability configurations should be sorted. Only valid in conjunction with sortBy
+   * @param {string} [parameters.section] - The section in which the searchability is defined. Default value is Products
+   * @param {object} [networkParameters] - Parameters relevant to the network request
+   * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
+   * @returns {Promise}
+   * @see https://docs.constructor.io/rest_api/searchabilities/#retrieve-searchabilities
+   * @example
+   * constructorio.catalog.retrieveSearchabilities({
+   *     page: 2,
+   *     numResultsPerPage: 50,
+   *     filters: { exact_searchable: true }
+   * });
+   */
+  retrieveSearchabilities(parameters = {}, networkParameters = {}) {
+    let requestUrl;
+    const { fetch } = this.options;
+    const controller = new AbortController();
+    const { signal } = controller;
+    const { name, page, offset, numResultsPerPage, filters, searchable, sortBy, sortOrder, section = 'Products' } = parameters;
+    const additionalQueryParams = {};
+
+    if (!helpers.isNil(page)) {
+      additionalQueryParams.page = page;
+    }
+
+    if (!helpers.isNil(offset)) {
+      additionalQueryParams.offset = offset;
+    }
+
+    if (!helpers.isNil(numResultsPerPage)) {
+      additionalQueryParams.num_results_per_page = numResultsPerPage;
+    }
+
+    if (filters) {
+      additionalQueryParams.filters = filters;
+    }
+
+    if (searchable) {
+      additionalQueryParams.searchable = searchable;
+    }
+
+    if (sortBy) {
+      additionalQueryParams.sort_by = sortBy;
+    }
+
+    if (sortOrder) {
+      additionalQueryParams.sort_order = sortOrder;
+    }
+
+    if (sortOrder) {
+      additionalQueryParams.sort_order = sortOrder;
+    }
+
+    if (section) {
+      additionalQueryParams.section = section;
+    }
+
+    if (name) {
+      if (additionalQueryParams.filters) {
+        additionalQueryParams.filters.name = name;
+      } else {
+        additionalQueryParams.filters = { name };
+      }
+    }
+
+    try {
+      requestUrl = createCatalogUrl('searchabilities', this.options, additionalQueryParams);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+
+    // Handle network timeout if specified
+    helpers.applyNetworkTimeout(this.options, networkParameters, controller);
+
+    return fetch(requestUrl, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...helpers.createAuthHeader(this.options),
+      },
+      signal,
+    }).then((response) => {
+      if (response.ok) {
+        return response.json();
+      }
+
+      return helpers.throwHttpErrorFromResponse(new Error(), response);
+    });
+  }
 }
 
 module.exports = Catalog;

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -598,7 +598,7 @@ declare class Catalog {
   ): Promise<FacetOptionConfiguration>;
 
   retrieveSearchabilities(
-    parameters: RetrieveSearchabilitiesParameters,
+    parameters?: RetrieveSearchabilitiesParameters,
     networkParameters?: NetworkParameters
   ): Promise<{
     searchabilities: SearchabilityConfigurationResponse[];

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -11,6 +11,7 @@ import {
   OneWaySynonymRelation,
   SynonymGroup,
   SearchabilityConfiguration,
+  SearchabilityConfigurationResponse,
 } from '.';
 
 export default Catalog;
@@ -106,7 +107,6 @@ export interface AddSynonymGroupParameters {
 }
 
 export interface ModifySynonymGroupParameters {
-  id: number;
   synonyms: string[];
 }
 
@@ -245,7 +245,7 @@ export type ModifyFacetOptionConfigurationParameters = ReplaceFacetOptionConfigu
 
 export interface RemoveFacetOptionConfiguration extends GetFacetOptionConfigurationParameters {}
 
-export interface retrieveSearchabilitiesParameters {
+export interface RetrieveSearchabilitiesParameters {
   name?: string;
   page?: number;
   offset?: number;
@@ -255,6 +255,10 @@ export interface retrieveSearchabilitiesParameters {
   sortBy?: string;
   sortOrder?: string;
   section?: string;
+}
+
+export interface PatchSearchabilitiesParameters {
+  searchabilities: SearchabilityConfiguration[],
 }
 
 declare class Catalog {
@@ -594,10 +598,17 @@ declare class Catalog {
   ): Promise<FacetOptionConfiguration>;
 
   retrieveSearchabilities(
-    parameters: retrieveSearchabilitiesParameters,
+    parameters: RetrieveSearchabilitiesParameters,
     networkParameters?: NetworkParameters
   ): Promise<{
-    searchabilities: SearchabilityConfiguration[];
+    searchabilities: SearchabilityConfigurationResponse[];
     total_count: number;
+  }>;
+
+  patchSearchabilities(
+    parameters: PatchSearchabilitiesParameters,
+    networkParameters?: NetworkParameters
+  ): Promise<{
+    searchabilities: SearchabilityConfigurationResponse[];
   }>;
 }

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -10,6 +10,7 @@ import {
   RedirectRuleResponse,
   OneWaySynonymRelation,
   SynonymGroup,
+  SearchabilityConfiguration,
 } from '.';
 
 export default Catalog;
@@ -243,6 +244,18 @@ export type ReplaceFacetOptionConfigurationParameters = {
 export type ModifyFacetOptionConfigurationParameters = ReplaceFacetOptionConfigurationParameters
 
 export interface RemoveFacetOptionConfiguration extends GetFacetOptionConfigurationParameters {}
+
+export interface retrieveSearchabilitiesParameters {
+  name?: string;
+  page?: number;
+  offset?: number;
+  numResultsPerPage?: number;
+  filters?: Record<string, any>;
+  searchable?: boolean;
+  sortBy?: string;
+  sortOrder?: string;
+  section?: string;
+}
 
 declare class Catalog {
   constructor(options: ConstructorClientOptions);
@@ -579,4 +592,12 @@ declare class Catalog {
     parameters: RemoveFacetOptionConfiguration,
     networkParameters?: NetworkParameters
   ): Promise<FacetOptionConfiguration>;
+
+  retrieveSearchabilities(
+    parameters: retrieveSearchabilitiesParameters,
+    networkParameters?: NetworkParameters
+  ): Promise<{
+    searchabilities: SearchabilityConfiguration[];
+    total_count: number;
+  }>;
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -299,7 +299,7 @@ export type FilterExpressionRange = {
 
 export type FilterExpressionRangeValue = ['-inf' | number, 'inf' | number];
 
-export interface SearchabilityConfiguration {
+export interface SearchabilityConfigurationResponse {
   name: string;
   fuzzy_searchable: boolean,
   exact_searchable: boolean,
@@ -308,4 +308,13 @@ export interface SearchabilityConfiguration {
   hidden: boolean,
   created_at: string,
   updated_at: string
+}
+
+export interface SearchabilityConfiguration {
+  name: string;
+  fuzzySearchable: boolean,
+  exactSearchable: boolean,
+  type: string,
+  displayable: boolean,
+  hidden: boolean,
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -312,9 +312,9 @@ export interface SearchabilityConfigurationResponse {
 
 export interface SearchabilityConfiguration {
   name: string;
-  fuzzySearchable: boolean,
-  exactSearchable: boolean,
-  type: string,
-  displayable: boolean,
-  hidden: boolean,
+  fuzzySearchable?: boolean,
+  exactSearchable?: boolean,
+  type?: string,
+  displayable?: boolean,
+  hidden?: boolean,
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -298,3 +298,14 @@ export type FilterExpressionRange = {
 };
 
 export type FilterExpressionRangeValue = ['-inf' | number, 'inf' | number];
+
+export interface SearchabilityConfiguration {
+  name: string;
+  fuzzy_searchable: boolean,
+  exact_searchable: boolean,
+  type: string,
+  displayable: boolean,
+  hidden: boolean,
+  created_at: string,
+  updated_at: string
+}

--- a/src/types/tests/catalog.test-d.ts
+++ b/src/types/tests/catalog.test-d.ts
@@ -7,7 +7,7 @@ import {
   OneWaySynonymRelation,
   RedirectRuleResponse,
   Variation,
-  SearchabilityConfiguration,
+  SearchabilityConfigurationResponse,
 } from '..';
 
 expectAssignable<Item>({
@@ -109,7 +109,7 @@ expectAssignable<FacetOptionConfiguration>({
   hidden: false,
 });
 
-expectAssignable<SearchabilityConfiguration>({
+expectAssignable<SearchabilityConfigurationResponse>({
   name: 'groups',
   fuzzy_searchable: false,
   exact_searchable: false,

--- a/src/types/tests/catalog.test-d.ts
+++ b/src/types/tests/catalog.test-d.ts
@@ -7,6 +7,7 @@ import {
   OneWaySynonymRelation,
   RedirectRuleResponse,
   Variation,
+  SearchabilityConfiguration,
 } from '..';
 
 expectAssignable<Item>({
@@ -106,4 +107,15 @@ expectAssignable<FacetOptionConfiguration>({
   position: null,
   data: null,
   hidden: false,
+});
+
+expectAssignable<SearchabilityConfiguration>({
+  name: 'groups',
+  fuzzy_searchable: false,
+  exact_searchable: false,
+  type: 'string',
+  displayable: true,
+  hidden: false,
+  created_at: '2019-04-12T18:15:30',
+  updated_at: '2019-04-12T18:15:30',
 });


### PR DESCRIPTION
Adds support for 
https://docs.constructor.io/rest_api/searchabilities/