### PR TITLE
Update SearchParameters Type to include offset & Update Fetch Type to Reflect Fetch API

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -17,7 +17,7 @@ export interface ConstructorClientOptions {
   securityToken?: string;
   version?: string;
   serviceUrl?: string;
-  fetch?: () => any;
+  fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   networkParameters?: NetworkParameters;
 }
 

--- a/src/types/search.d.ts
+++ b/src/types/search.d.ts
@@ -17,6 +17,7 @@ export default Search;
 
 export interface SearchParameters {
   page?: number;
+  offset?: number;
   resultsPerPage?: number;
   filters?: Record<string, any>;
   sortBy?: string;


### PR DESCRIPTION
- The offset parameter is missing in the SearchParameters type.

- Updated type for Fetch to better reflect Web Standard Fetch API.