### PR TITLE
Remove testCells from examples.

### DIFF
--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -133,10 +133,6 @@ class Autocomplete {
    *     filters: {
    *         size: 'medium'
    *     },
-   * }, {
-   *     testCells: {
-   *         testName: 'cellName',
-   *    },
    * });
    */
   getAutocompleteResults(query, parameters = {}, userParameters = {}, networkParameters = {}) {

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -277,10 +277,6 @@ class Browse {
    *     filters: {
    *         size: 'medium'
    *     },
-   * }, {
-   *     testCells: {
-   *         testName: 'cellName',
-   *    },
    * });
    */
   getBrowseResults(filterName, filterValue, parameters = {}, userParameters = {}, networkParameters = {}) {
@@ -361,10 +357,6 @@ class Browse {
    *     filters: {
    *         size: 'medium'
    *     },
-   * }, {
-   *     testCells: {
-   *         'testName': 'cellName',
-   *    },
    * });
    */
   getBrowseResultsForItemIds(itemIds, parameters = {}, userParameters = {}, networkParameters = {}) {
@@ -433,10 +425,6 @@ class Browse {
    *     fmtOptions: {
    *         groups_max_depth: 2
    *     }
-   * }, {
-   *     testCells: {
-   *         'testName': 'cellName',
-   *    },
    * });
    */
   getBrowseGroups(parameters = {}, userParameters = {}, networkParameters = {}) {
@@ -492,10 +480,6 @@ class Browse {
    * constructorio.browse.getBrowseFacets({
    *     page: 1,
    *     resultsPerPage: 10,
-   * }, {
-   *     testCells: {
-   *         'testName': 'cellName',
-   *    },
    * });
    */
   getBrowseFacets(parameters = {}, userParameters = {}, networkParameters = {}) {

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -120,10 +120,6 @@ class Recommendations {
    *     filters: {
    *         size: 'medium'
    *     },
-   * }, {
-   *     testCells: {
-   *         testName: 'cellName',
-   *    },
    * });
    */
   getRecommendations(podId, parameters = {}, userParameters = {}, networkParameters = {}) {

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -197,10 +197,6 @@ class Search {
    *     filters: {
    *         size: 'medium'
    *     },
-   * }, {
-   *     testCells: {
-   *         testName: 'cellName',
-   *    },
    * });
    */
 


### PR DESCRIPTION
`testCells` is an optional parameter and not commonly passed. Removing to create more consistency in code examples between client-javascript and this repository.