### PR TITLE
[CSL-3108] Trim space adjustments

### DIFF
--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -400,6 +400,22 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
+    it('Should return a response with a valid query consisting of only non-breaking spaces', (done) => {
+      const { autocomplete } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      autocomplete.getAutocompleteResults('  ').then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('sections').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        done();
+      });
+    });
+
     it('Should return a variations_map object in the response', (done) => {
       const variationsMap = {
         group_by: [
@@ -469,6 +485,24 @@ describe('ConstructorIO - Autocomplete', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(requestedUrlParams).to.have.property('filters');
         expect(requestedUrlParams.filters).to.have.property('keywords').to.equal(Object.values(filters)[0][0]);
+        done();
+      });
+    });
+
+    it('Should not trim spaces from query', (done) => {
+      const queryWithSpaces = ` ${query}  `;
+      const { autocomplete } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      autocomplete.getAutocompleteResults(queryWithSpaces).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res.request.term).to.equal(queryWithSpaces);
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('sections').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
         done();
       });
     });

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -473,7 +473,7 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
-    it.only('Should not trim spaces from query', (done) => {
+    it('Should not trim spaces from query', (done) => {
       const queryWithSpaces = ` ${query}  `;
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -407,8 +407,6 @@ describe('ConstructorIO - Autocomplete', () => {
       });
 
       autocomplete.getAutocompleteResults('  ').then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
@@ -497,8 +495,6 @@ describe('ConstructorIO - Autocomplete', () => {
       });
 
       autocomplete.getAutocompleteResults(queryWithSpaces).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
         expect(res.request.term).to.equal(queryWithSpaces);
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
@@ -625,6 +621,12 @@ describe('ConstructorIO - Autocomplete', () => {
       const { autocomplete } = new ConstructorIO(validOptions);
 
       return expect(autocomplete.getAutocompleteResults(null)).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when query consisting of only non-breaking spaces is provided', () => {
+      const { autocomplete } = new ConstructorIO(validOptions);
+
+      return expect(autocomplete.getAutocompleteResults('  ')).to.eventually.be.rejected;
     });
 
     it('Should be rejected when invalid numResults parameter is provided', () => {

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -473,7 +473,7 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
-    it('Should not trim spaces from query', (done) => {
+    it('Should not trim non-breaking spaces from query', (done) => {
       const queryWithSpaces = ` ${query}  `;
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -400,20 +400,6 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
-    it('Should return a response with a valid query consisting of only non-breaking spaces', (done) => {
-      const { autocomplete } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      autocomplete.getAutocompleteResults('  ').then((res) => {
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('sections').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        done();
-      });
-    });
-
     it('Should return a variations_map object in the response', (done) => {
       const variationsMap = {
         group_by: [

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -473,7 +473,7 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
-    it('Should not trim non-breaking spaces from query', (done) => {
+    it.only('Should not trim spaces from query', (done) => {
       const queryWithSpaces = ` ${query}  `;
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,
@@ -607,12 +607,6 @@ describe('ConstructorIO - Autocomplete', () => {
       const { autocomplete } = new ConstructorIO(validOptions);
 
       return expect(autocomplete.getAutocompleteResults(null)).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when query consisting of only non-breaking spaces is provided', () => {
-      const { autocomplete } = new ConstructorIO(validOptions);
-
-      return expect(autocomplete.getAutocompleteResults('  ')).to.eventually.be.rejected;
     });
 
     it('Should be rejected when invalid numResults parameter is provided', () => {

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const ConstructorIO = require('../../../test/constructorio'); // eslint-disable-line import/extensions
 const helpers = require('../../mocha.helpers');
-const utilsHelpers = require('../../../src/utils/helpers');
 
 const nodeFetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
@@ -576,22 +575,6 @@ describe('ConstructorIO - Search', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.sort_by).to.equal(sortByExpected);
         expect(requestedUrlParams).to.have.property('sort_by').to.equal(sortByExpected);
-        done();
-      });
-    });
-
-    it('Should trim non-breaking spaces from query', (done) => {
-      const queryWithSpaces = ` ${query}  `;
-      const { search } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      search.getSearchResults(queryWithSpaces).then((res) => {
-        expect(res.request.term).to.equal(utilsHelpers.trimNonBreakingSpaces(queryWithSpaces));
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
         done();
       });
     });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -543,6 +543,22 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
+    it.only('Should not trim spaces from query', (done) => {
+      const queryWithSpaces = ` ${query}  `;
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      search.getSearchResults(queryWithSpaces).then((res) => {
+        expect(res.request.term).to.equal(queryWithSpaces);
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        done();
+      });
+    });
+
     it('Should properly transform non-breaking spaces in parameters', (done) => {
       const breakingSpaces = '   ';
       const sortBy = `relevance ${breakingSpaces} relevance`;
@@ -679,12 +695,6 @@ describe('ConstructorIO - Search', () => {
       const { search } = new ConstructorIO(validOptions);
 
       return expect(search.getSearchResults(null, { section })).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when query consisting of only non-breaking spaces is provided', () => {
-      const { search } = new ConstructorIO(validOptions);
-
-      return expect(search.getSearchResults('  ', { section })).to.eventually.be.rejected;
     });
 
     it('Should be rejected when invalid page parameter is provided', () => {

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -543,7 +543,7 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
-    it.only('Should not trim spaces from query', (done) => {
+    it('Should not trim spaces from query', (done) => {
       const queryWithSpaces = ` ${query}  `;
       const { search } = new ConstructorIO({
         apiKey: testApiKey,

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -572,8 +572,6 @@ describe('ConstructorIO - Search', () => {
       });
 
       search.getSearchResults(queryWithSpaces).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
         expect(res.request.term).to.equal(utilsHelpers.trimNonBreakingSpaces(queryWithSpaces));
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -23,8 +23,11 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
   queryParams.i = clientId;
   queryParams.s = sessionId;
 
-  // Validate query (term) is provided
-  if (!query || typeof query !== 'string') {
+  // Trim non breaking spaces from query
+  const queryTrimmed = helpers.trimNonBreakingSpaces(query);
+
+  // Validate query (term) is provided and consists of more than non-breaking spaces
+  if (!queryTrimmed || typeof queryTrimmed !== 'string') {
     throw new Error('query is a required parameter of type string');
   }
 
@@ -112,6 +115,7 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
   const queryString = qs.stringify(queryParams, { indices: false });
   const cleanedQuery = query.replace(/^\//, '|'); // For compatibility with backend API
 
+  // Note: it is intentional that query is dispatched without being trimmed (`queryTrimmed`)
   return `${serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(cleanedQuery)}?${queryString}`;
 }
 

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -112,7 +112,7 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
   const queryString = qs.stringify(queryParams, { indices: false });
   const cleanedQuery = query.replace(/^\//, '|'); // For compatibility with backend API
 
-  return `${serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(cleanedQuery))}?${queryString}`;
+  return `${serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(cleanedQuery)}?${queryString}`;
 }
 
 /**

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -23,11 +23,8 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
   queryParams.i = clientId;
   queryParams.s = sessionId;
 
-  // Trim non breaking spaces from query
-  const queryTrimmed = helpers.trimNonBreakingSpaces(query);
-
-  // Validate query (term) is provided and consists of more than non-breaking spaces
-  if (!queryTrimmed || typeof queryTrimmed !== 'string') {
+  // Validate query (term) is provided
+  if (!query || typeof query !== 'string') {
     throw new Error('query is a required parameter of type string');
   }
 
@@ -115,7 +112,7 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
   const queryString = qs.stringify(queryParams, { indices: false });
   const cleanedQuery = query.replace(/^\//, '|'); // For compatibility with backend API
 
-  // Note: it is intentional that query is dispatched without being trimmed (`queryTrimmed`)
+  // Note: it is intentional that query is dispatched without being trimmed
   return `${serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(cleanedQuery)}?${queryString}`;
 }
 

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -25,6 +25,9 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
   queryParams.i = clientId;
   queryParams.s = sessionId;
 
+  // Trim non breaking spaces from query
+  query = helpers.trimNonBreakingSpaces(query);
+
   // Validate query (term) is provided
   if (!query || typeof query !== 'string') {
     throw new Error('query is a required parameter of type string');
@@ -145,7 +148,7 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
 
   const searchUrl = isVoiceSearch ? 'search/natural_language' : 'search';
 
-  return `${serviceUrl}/${searchUrl}/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(query))}?${queryString}`;
+  return `${serviceUrl}/${searchUrl}/${helpers.encodeURIComponentRFC3986(query)}?${queryString}`;
 }
 
 /**

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -26,10 +26,10 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
   queryParams.s = sessionId;
 
   // Trim non breaking spaces from query
-  query = helpers.trimNonBreakingSpaces(query);
+  const queryTrimmed = helpers.trimNonBreakingSpaces(query);
 
-  // Validate query (term) is provided
-  if (!query || typeof query !== 'string') {
+  // Validate query (term) is provided and consists of more than non-breaking spaces
+  if (!queryTrimmed || typeof queryTrimmed !== 'string') {
     throw new Error('query is a required parameter of type string');
   }
 
@@ -148,7 +148,7 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
 
   const searchUrl = isVoiceSearch ? 'search/natural_language' : 'search';
 
-  return `${serviceUrl}/${searchUrl}/${helpers.encodeURIComponentRFC3986(query)}?${queryString}`;
+  return `${serviceUrl}/${searchUrl}/${helpers.encodeURIComponentRFC3986(queryTrimmed)}?${queryString}`;
 }
 
 /**

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -25,11 +25,8 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
   queryParams.i = clientId;
   queryParams.s = sessionId;
 
-  // Trim non breaking spaces from query
-  const queryTrimmed = helpers.trimNonBreakingSpaces(query);
-
-  // Validate query (term) is provided and consists of more than non-breaking spaces
-  if (!queryTrimmed || typeof queryTrimmed !== 'string') {
+  // Validate query (term) is provided
+  if (!query || typeof query !== 'string') {
     throw new Error('query is a required parameter of type string');
   }
 
@@ -148,7 +145,8 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
 
   const searchUrl = isVoiceSearch ? 'search/natural_language' : 'search';
 
-  return `${serviceUrl}/${searchUrl}/${helpers.encodeURIComponentRFC3986(queryTrimmed)}?${queryString}`;
+  // Note: it is intentional that query is dispatched without being trimmed
+  return `${serviceUrl}/${searchUrl}/${helpers.encodeURIComponentRFC3986(query)}?${queryString}`;
 }
 
 /**


### PR DESCRIPTION
It has been raised that autocomplete requests should not have non-breaking spaces trimmed from queries (terms). This pull request aims to do the following:

a. No longer trim non-breaking spaces from autocomplete and search requests

b. Add tests to cover the above case.

Reference ticket: https://linear.app/constructor/issue/CSL-3108/investigate-error-with-space-input-in-constructorio-node