### PR TITLE
CSL-3133 Tracking space trimming

### DIFF
--- a/spec/mocha.helpers.js
+++ b/spec/mocha.helpers.js
@@ -40,8 +40,21 @@ const extractHeadersFromFetch = (fetch) => {
   return null;
 };
 
+// Extract request URL as string from request
+const extractUrlFromFetch = (fetch) => {
+  const lastCallArguments = fetch && fetch.args && fetch.args[fetch.args.length - 1];
+  const requestUrl = lastCallArguments[0];
+
+  if (requestUrl) {
+    return requestUrl;
+  }
+
+  return null;
+};
+
 module.exports = {
   extractUrlParamsFromFetch,
   extractBodyParamsFromFetch,
   extractHeadersFromFetch,
+  extractUrlFromFetch,
 };

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -7,6 +7,7 @@ const sinonChai = require('sinon-chai');
 const cloneDeep = require('lodash.clonedeep');
 const ConstructorIO = require('../../../test/constructorio'); // eslint-disable-line import/extensions
 const helpers = require('../../mocha.helpers');
+const { encodeURIComponentRFC3986 } = require('../../../src/utils/helpers');
 
 const nodeFetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
@@ -1445,6 +1446,31 @@ describe('ConstructorIO - Tracker', () => {
       )).to.equal(true);
     });
 
+    it.only('Should not trim term or original query parameters containing extra spacing', (done) => {
+      const spaceTerm = `   ${term}   `;
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', () => {
+        const requestUrl = helpers.extractUrlFromFetch(fetchSpy);
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(requestParams).to.have.property('original_query').to.equal(spaceTerm);
+        expect(requestUrl).to.include(`/autocomplete/${encodeURIComponentRFC3986(spaceTerm)}/select`);
+
+        done();
+      });
+
+      expect(tracker.trackAutocompleteSelect(spaceTerm, {
+        ...requiredParameters,
+        originalQuery: spaceTerm,
+      }, userParameters)).to.equal(true);
+    });
+
     it('Should throw an error when invalid term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -2363,6 +2389,33 @@ describe('ConstructorIO - Tracker', () => {
       )).to.equal(true);
     });
 
+    it.only('Should not trim term or original query parameters containing extra spacing', (done) => {
+      const spaceTerm = `   ${term}   `;
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', () => {
+        const requestUrl = helpers.extractUrlFromFetch(fetchSpy);
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        console.dir(requestUrl);
+
+        // Request
+        expect(requestParams).to.have.property('original_query').to.equal(spaceTerm);
+        expect(requestUrl).to.include(`/autocomplete/${encodeURIComponentRFC3986(spaceTerm)}/search`);
+
+        done();
+      });
+
+      expect(tracker.trackSearchSubmit(spaceTerm, {
+        ...requiredParameters,
+        originalQuery: spaceTerm,
+      }, userParameters)).to.equal(true);
+    });
+
     it('Should throw an error when invalid term is provided', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -2873,7 +2926,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchResultsLoaded(term, { num_results: 0 }, userParameters)).to.equal(true);
     });
 
-    it('Should trim term parameter if extra spaces are provided', (done) => {
+    it.only('Should not trim term parameter containing extra spacing', (done) => {
       const spaceTerm = `   ${term}   `;
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -2884,7 +2937,7 @@ describe('ConstructorIO - Tracker', () => {
       tracker.on('success', () => {
         const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
-        expect(requestParams).to.have.property('term').to.equal(term);
+        expect(requestParams).to.have.property('term').to.equal(spaceTerm);
 
         done();
       });
@@ -4225,7 +4278,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, fullParameters, userParameters)).to.equal(true);
     });
 
-    it('Should trim term parameter if extra spaces are provided', (done) => {
+    it.only('Should not trim term parameter containing extra spacing', (done) => {
       const spaceTerm = `   ${term}   `;
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1446,7 +1446,7 @@ describe('ConstructorIO - Tracker', () => {
       )).to.equal(true);
     });
 
-    it.only('Should not trim term or original query parameters containing extra spacing', (done) => {
+    it('Should not trim term or original query parameters containing extra spacing', (done) => {
       const spaceTerm = `   ${term}   `;
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -2389,7 +2389,7 @@ describe('ConstructorIO - Tracker', () => {
       )).to.equal(true);
     });
 
-    it.only('Should not trim term or original query parameters containing extra spacing', (done) => {
+    it('Should not trim term or original query parameters containing extra spacing', (done) => {
       const spaceTerm = `   ${term}   `;
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -2400,8 +2400,6 @@ describe('ConstructorIO - Tracker', () => {
       tracker.on('success', () => {
         const requestUrl = helpers.extractUrlFromFetch(fetchSpy);
         const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        console.dir(requestUrl);
 
         // Request
         expect(requestParams).to.have.property('original_query').to.equal(spaceTerm);
@@ -2926,7 +2924,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackSearchResultsLoaded(term, { num_results: 0 }, userParameters)).to.equal(true);
     });
 
-    it.only('Should not trim term parameter containing extra spacing', (done) => {
+    it('Should not trim term parameter containing extra spacing', (done) => {
       const spaceTerm = `   ${term}   `;
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -3520,6 +3518,26 @@ describe('ConstructorIO - Tracker', () => {
       });
 
       expect(tracker.trackSearchResultClick(term, legacyParameters, userParameters)).to.equal(true);
+    });
+
+    it('Should not trim term parameter containing extra spacing', (done) => {
+      const spaceTerm = `   ${term}   `;
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...userParameters,
+      });
+
+      tracker.on('success', () => {
+        const requestUrl = helpers.extractUrlFromFetch(fetchSpy);
+
+        // Request
+        expect(requestUrl).to.include(`/autocomplete/${encodeURIComponentRFC3986(spaceTerm)}/click_through`);
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(spaceTerm, requiredParameters, userParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid term is provided', () => {
@@ -4278,7 +4296,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, fullParameters, userParameters)).to.equal(true);
     });
 
-    it.only('Should not trim term parameter containing extra spacing', (done) => {
+    it('Should not trim term parameter containing extra spacing', (done) => {
       const spaceTerm = `   ${term}   `;
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -4289,7 +4307,7 @@ describe('ConstructorIO - Tracker', () => {
       tracker.on('success', () => {
         const bodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
 
-        expect(bodyParams).to.have.property('search_term').to.equal(term);
+        expect(bodyParams).to.have.property('search_term').to.equal(spaceTerm);
 
         done();
       });

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -153,7 +153,7 @@ function createBrowseUrlFromFilter(filterName, filterValue, parameters, userPara
   const queryParams = createQueryParams(parameters, userParameters, options);
   const queryString = qs.stringify(queryParams, { indices: false });
 
-  return `${serviceUrl}/browse/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(filterName))}/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(filterValue))}?${queryString}`;
+  return `${serviceUrl}/browse/${helpers.encodeURIComponentRFC3986(helpers.normalizeSpaces(filterName).trim())}/${helpers.encodeURIComponentRFC3986(helpers.normalizeSpaces(filterValue).trim())}?${queryString}`;
 }
 
 // Create URL from supplied IDs and parameters

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -84,7 +84,7 @@ function createRecommendationsUrl(podId, parameters, userParameters, options) {
 
   const queryString = qs.stringify(queryParams, { indices: false });
 
-  return `${serviceUrl}/recommendations/v1/pods/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(podId))}?${queryString}`;
+  return `${serviceUrl}/recommendations/v1/pods/${helpers.encodeURIComponentRFC3986(helpers.normalizeSpaces(podId).trim())}?${queryString}`;
 }
 
 /**

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -418,7 +418,7 @@ class Tracker {
     if (term && typeof term === 'string') {
       // Ensure parameters are provided (required)
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
-        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(term)}/select?`;
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(helpers.normalizeSpaces(term))}/select?`;
         const queryParams = {};
         const {
           original_query,
@@ -516,7 +516,7 @@ class Tracker {
     if (term && typeof term === 'string') {
       // Ensure parameters are provided (required)
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
-        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(term)}/search?`;
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(helpers.normalizeSpaces(term))}/search?`;
         const queryParams = {};
         const {
           original_query,
@@ -700,7 +700,7 @@ class Tracker {
     if (term && typeof term === 'string') {
       // Ensure parameters are provided (required)
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
-        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(term)}/click_through?`;
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(helpers.normalizeSpaces(term))}/click_through?`;
         const queryParams = {};
         const {
           item_name,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -700,7 +700,7 @@ class Tracker {
     if (term && typeof term === 'string') {
       // Ensure parameters are provided (required)
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
-        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(term))}/click_through?`;
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(term)}/click_through?`;
         const queryParams = {};
         const {
           item_name,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -418,7 +418,7 @@ class Tracker {
     if (term && typeof term === 'string') {
       // Ensure parameters are provided (required)
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
-        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(term))}/select?`;
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(term)}/select?`;
         const queryParams = {};
         const {
           original_query,
@@ -516,7 +516,7 @@ class Tracker {
     if (term && typeof term === 'string') {
       // Ensure parameters are provided (required)
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
-        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(helpers.trimNonBreakingSpaces(term))}/search?`;
+        const url = `${this.options.serviceUrl}/autocomplete/${helpers.encodeURIComponentRFC3986(term)}/search?`;
         const queryParams = {};
         const {
           original_query,

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -7,7 +7,9 @@ const PII_REGEX = {
 };
 
 const utils = {
-  trimNonBreakingSpaces: (string) => string.replace(/\s/g, ' ').trim(),
+  // Replace non-breaking spaces (or any other type of spaces caught by the regex)
+  // - with a regular white space
+  normalizeSpaces: (string) => string.replace(/\s/g, ' '),
 
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
   encodeURIComponentRFC3986: (string) => encodeURIComponent(string).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`),
@@ -19,10 +21,12 @@ const utils = {
       const excludeTrimList = ['term', 'original_query', 'search_term'];
       const paramValue = paramsObj[paramKey];
 
-      if (typeof paramValue === 'string' && !excludeTrimList.includes(paramKey)) {
-        // Replace non-breaking spaces (or any other type of spaces caught by the regex)
-        // - with a regular white space
-        cleanedParams[paramKey] = utils.trimNonBreakingSpaces(paramValue);
+      if (typeof paramValue === 'string') {
+        cleanedParams[paramKey] = utils.normalizeSpaces(paramValue);
+
+        if (!excludeTrimList.includes(paramKey)) {
+          cleanedParams[paramKey] = cleanedParams[paramKey].trim();
+        }
       } else {
         cleanedParams[paramKey] = paramValue;
       }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -16,7 +16,7 @@ const utils = {
     const cleanedParams = {};
 
     Object.keys(paramsObj).forEach((paramKey) => {
-      const excludeTrimList = ['term', 'originalQuery', 'original_query'];
+      const excludeTrimList = ['term', 'original_query', 'search_term'];
       const paramValue = paramsObj[paramKey];
 
       if (typeof paramValue === 'string' && !excludeTrimList.includes(paramKey)) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -16,9 +16,10 @@ const utils = {
     const cleanedParams = {};
 
     Object.keys(paramsObj).forEach((paramKey) => {
+      const excludeTrimList = ['term', 'originalQuery', 'original_query'];
       const paramValue = paramsObj[paramKey];
 
-      if (typeof paramValue === 'string') {
+      if (typeof paramValue === 'string' && !excludeTrimList.includes(paramKey)) {
         // Replace non-breaking spaces (or any other type of spaces caught by the regex)
         // - with a regular white space
         cleanedParams[paramKey] = utils.trimNonBreakingSpaces(paramValue);


### PR DESCRIPTION
Related to #183 

Do not trim space from "term" related tracking parameters (`term`, `original_query`, `search_term`)