### PR TITLE
[CSL-3107] - Add total_questions to the response object type

### DIFF
--- a/src/types/quizzes.d.ts
+++ b/src/types/quizzes.d.ts
@@ -54,6 +54,7 @@ export interface NextQuestionResponse extends Record<string, any> {
   quiz_version_id: string;
   quiz_id: string;
   quiz_session_id: string;
+  total_questions: number;
 }
 
 export interface QuizResultsResponse extends Record<string, any> {

--- a/src/types/tests/quizzes.test-d.ts
+++ b/src/types/tests/quizzes.test-d.ts
@@ -38,6 +38,7 @@ expectAssignable<NextQuestionResponse>(
     quiz_version_id: '6bfaa6d5-7272-466b-acd9-4bcf322a2f1e',
     quiz_id: 'test-quiz',
     quiz_session_id: '132feaa5-9968-4c5d-8605-d128747188d6',
+    total_questions: 1,
   },
 );
 
@@ -59,6 +60,7 @@ expectAssignable<NextQuestionResponse>({
   quiz_version_id: '6bfaa6d5-7272-466b-acd9-4bcf322a2f1e',
   quiz_id: 'test-quiz',
   quiz_session_id: '132feaa5-9968-4c5d-8605-d128747188d6',
+  total_questions: 1,
 });
 
 expectAssignable<QuizResultsResponse>({


### PR DESCRIPTION
https://linear.app/constructor/issue/CSL-3107/node-quizzes-updates-total-questions-attribute 

- Adds `total_questions` to the response object type and fixes tests 

[Based on](https://github.com/Constructor-io/constructorio-client-javascript/pull/272)