### PR TITLE
[csl-3140] - Remove hardcoded versionId from Quizzes tests

### DIFF
--- a/spec/src/modules/quizzes.js
+++ b/spec/src/modules/quizzes.js
@@ -18,7 +18,6 @@ const clientId = '2b23dd74-5672-4379-878c-9182938d2710';
 const sessionId = '2';
 const clientVersion = 'cio-mocha';
 const skipNetworkTimeoutTests = process.env.SKIP_NETWORK_TIMEOUT_TESTS === 'true';
-const quizVersionId = 'e03210db-0cc6-459c-8f17-bf014c4f554d';
 const quizSessionId = 'session-id';
 
 describe('ConstructorIO - Quizzes', () => {
@@ -88,17 +87,22 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizNextQuestion(validQuizId, { quizVersionId, quizSessionId }).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+      return quizzes.getQuizNextQuestion(validQuizId, { quizSessionId }).then((initialResponse) => {
+        const { quiz_version_id: quizVersionId } = initialResponse;
 
-        expect(res).to.have.property('quiz_version_id').to.be.an('string').to.equal(quizVersionId);
-        expect(res).to.have.property('quiz_session_id').to.be.an('string');
-        expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
-        expect(res).to.have.property('next_question').to.be.an('object');
-        expect(res.next_question.id).to.equal(1);
-        expect(res.next_question.options[0].id).to.equal(1);
-        expect(requestedUrlParams).to.have.property('quiz_version_id').to.equal(quizVersionId);
-        expect(requestedUrlParams).to.have.property('quiz_session_id').to.equal(quizSessionId);
+        return quizzes.getQuizNextQuestion(validQuizId, { quizSessionId, quizVersionId }).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(res).to.have.property('quiz_version_id').to.be.an('string').to.equal(quizVersionId);
+          expect(res).to.have.property('quiz_session_id').to.be.an('string');
+          expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
+          expect(res).to.have.property('quiz_version_id').to.equal(quizVersionId);
+          expect(res).to.have.property('next_question').to.be.an('object');
+          expect(res.next_question.id).to.equal(1);
+          expect(res.next_question.options[0].id).to.equal(1);
+          expect(requestedUrlParams).to.have.property('quiz_version_id').to.equal(quizVersionId);
+          expect(requestedUrlParams).to.have.property('quiz_session_id').to.equal(quizSessionId);
+        });
       });
     });
 
@@ -269,18 +273,23 @@ describe('ConstructorIO - Quizzes', () => {
       });
 
       // eslint-disable-next-line max-len
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, quizVersionId, quizSessionId }).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, quizSessionId }).then((initialResponse) => {
+        const { quiz_version_id: quizVersionId } = initialResponse;
 
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        expect(res).to.have.property('quiz_version_id').to.equal(quizVersionId);
-        expect(res).to.have.property('quiz_session_id').to.equal(quizSessionId);
-        expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
-        expect(requestedUrlParams).to.have.property('quiz_version_id').to.equal(quizVersionId);
-        expect(requestedUrlParams).to.have.property('quiz_session_id').to.equal(quizSessionId);
+        // eslint-disable-next-line max-len
+        return quizzes.getQuizResults(validQuizId, { answers: validAnswers, quizVersionId, quizSessionId }).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(res).to.have.property('request').to.be.an('object');
+          expect(res).to.have.property('response').to.be.an('object');
+          expect(res).to.have.property('result_id').to.be.an('string');
+          expect(res.response).to.have.property('results').to.be.an('array');
+          expect(res).to.have.property('quiz_version_id').to.equal(quizVersionId);
+          expect(res).to.have.property('quiz_session_id').to.equal(quizSessionId);
+          expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
+          expect(requestedUrlParams).to.have.property('quiz_version_id').to.equal(quizVersionId);
+          expect(requestedUrlParams).to.have.property('quiz_session_id').to.equal(quizSessionId);
+        });
       });
     });
 

--- a/spec/src/modules/quizzes.js
+++ b/spec/src/modules/quizzes.js
@@ -87,7 +87,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizNextQuestion(validQuizId, { quizSessionId }).then((initialResponse) => {
+      return quizzes.getQuizNextQuestion(validQuizId).then((initialResponse) => {
         const { quiz_version_id: quizVersionId } = initialResponse;
 
         return quizzes.getQuizNextQuestion(validQuizId, { quizSessionId, quizVersionId }).then((res) => {
@@ -96,7 +96,6 @@ describe('ConstructorIO - Quizzes', () => {
           expect(res).to.have.property('quiz_version_id').to.be.an('string').to.equal(quizVersionId);
           expect(res).to.have.property('quiz_session_id').to.be.an('string');
           expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
-          expect(res).to.have.property('quiz_version_id').to.equal(quizVersionId);
           expect(res).to.have.property('next_question').to.be.an('object');
           expect(res.next_question.id).to.equal(1);
           expect(res.next_question.options[0].id).to.equal(1);
@@ -272,8 +271,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      // eslint-disable-next-line max-len
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, quizSessionId }).then((initialResponse) => {
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers }).then((initialResponse) => {
         const { quiz_version_id: quizVersionId } = initialResponse;
 
         // eslint-disable-next-line max-len


### PR DESCRIPTION
https://linear.app/constructor/issue/CSL-3140/[node]-remove-versionid-from-quizzes-tests

- removes hardcoded versionId from quizz tests and adjusts tests to check it's being passed properly 