### PR TITLE
[CSL 3342] Add parameters to getRecommendationsPod

### DIFF
--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -675,7 +675,7 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it.only('Should add the section query param when section parameter is provided', (done) => {
+    it('Should add the section query param when section parameter is provided', (done) => {
       const { recommendations } = new ConstructorIO({
         ...validOptions,
         fetch: fetchSpy,
@@ -691,7 +691,7 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it.only('Should not add the section query param if it is not provided', (done) => {
+    it('Should not add the section query param if it is not provided', (done) => {
       const { recommendations } = new ConstructorIO({
         ...validOptions,
         fetch: fetchSpy,

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -675,7 +675,7 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should add the section query param when section parameter is provided', (done) => {
+    it.only('Should add the section query param when section parameter is provided', (done) => {
       const { recommendations } = new ConstructorIO({
         ...validOptions,
         fetch: fetchSpy,
@@ -691,7 +691,7 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should not add the section query param if it is not provided', (done) => {
+    it.only('Should not add the section query param if it is not provided', (done) => {
       const { recommendations } = new ConstructorIO({
         ...validOptions,
         fetch: fetchSpy,

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -682,14 +682,11 @@ describe('ConstructorIO - Recommendations', () => {
       });
       const parameters = { section: 'Products' };
 
-      recommendations.getRecommendationPods(null, parameters).then((res) => {
+      recommendations.getRecommendationPods(null, parameters).then(() => {
         const url = helpers.extractUrlFromFetch(fetchSpy);
         const queryParam = '&section=Products';
 
         expect(url).to.contain(queryParam);
-        expect(res).to.be.an('object');
-        expect(res).to.have.property('pods');
-        expect(res).to.have.property('total_count');
         done();
       });
     });
@@ -701,14 +698,11 @@ describe('ConstructorIO - Recommendations', () => {
       });
       const parameters = {};
 
-      recommendations.getRecommendationPods(null, parameters).then((res) => {
+      recommendations.getRecommendationPods(null, parameters).then(() => {
         const url = helpers.extractUrlFromFetch(fetchSpy);
         const queryParam = '&section=Products';
 
         expect(url).not.to.contain(queryParam);
-        expect(res).to.be.an('object');
-        expect(res).to.have.property('pods');
-        expect(res).to.have.property('total_count');
         done();
       });
     });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -675,6 +675,44 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
+    it('Should add the section query param when section parameter is provided', (done) => {
+      const { recommendations } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+      const parameters = { section: 'Products' };
+
+      recommendations.getRecommendationPods(null, parameters).then((res) => {
+        const url = helpers.extractUrlFromFetch(fetchSpy);
+        const queryParam = '&section=Products';
+
+        expect(url).to.contain(queryParam);
+        expect(res).to.be.an('object');
+        expect(res).to.have.property('pods');
+        expect(res).to.have.property('total_count');
+        done();
+      });
+    });
+
+    it('Should not add the section query param if it is not provided', (done) => {
+      const { recommendations } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+      const parameters = {};
+
+      recommendations.getRecommendationPods(null, parameters).then((res) => {
+        const url = helpers.extractUrlFromFetch(fetchSpy);
+        const queryParam = '&section=Products';
+
+        expect(url).not.to.contain(queryParam);
+        expect(res).to.be.an('object');
+        expect(res).to.have.property('pods');
+        expect(res).to.have.property('total_count');
+        done();
+      });
+    });
+
     it('Should be rejected when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ ...validOptions, apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -201,12 +201,13 @@ class Recommendations {
    * @function getRecommendationPods
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
-   * @param {string} [section] - The section to return results from. Defaults to an empty string
+   * @param {object} [parameters] - Additional parameters to refine results
+   * @param {string} [parameters.section] - The section to return results from
    * @returns {Promise}
    * @example
    * constructorio.recommendations.getRecommendationPods();
    */
-  getRecommendationPods(networkParameters = {}, section = '') {
+  getRecommendationPods(networkParameters = {}, parameters = {}) {
     const {
       apiKey,
       serviceUrl,
@@ -215,8 +216,9 @@ class Recommendations {
     const controller = new AbortController();
     const { signal } = controller;
     const headers = {};
-    const sectionParam = section ? `&section=${section}` : '';
-    const requestUrl = `${serviceUrl}/v1/recommendation_pods?key=${apiKey}${sectionParam}`.trim();
+    const rawQueryParams = qs.stringify(parameters);
+    const queryParams = rawQueryParams ? `&${rawQueryParams}` : '';
+    const requestUrl = `${serviceUrl}/v1/recommendation_pods?key=${apiKey}${queryParams}`.trim();
 
     Object.assign(headers, helpers.combineCustomHeaders(this.options, networkParameters));
 

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -216,7 +216,8 @@ class Recommendations {
     const controller = new AbortController();
     const { signal } = controller;
     const headers = {};
-    const rawQueryParams = qs.stringify(parameters);
+    const { section } = parameters;
+    const rawQueryParams = section ? qs.stringify({ section }) : '';
     const queryParams = rawQueryParams ? `&${rawQueryParams}` : '';
     const requestUrl = `${serviceUrl}/v1/recommendation_pods?key=${apiKey}${queryParams}`.trim();
 

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -201,11 +201,12 @@ class Recommendations {
    * @function getRecommendationPods
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
+   * @param {string} [section] - The section to return results from. Defaults to an empty string
    * @returns {Promise}
    * @example
    * constructorio.recommendations.getRecommendationPods();
    */
-  getRecommendationPods(networkParameters = {}) {
+  getRecommendationPods(networkParameters = {}, section = '') {
     const {
       apiKey,
       serviceUrl,
@@ -214,7 +215,8 @@ class Recommendations {
     const controller = new AbortController();
     const { signal } = controller;
     const headers = {};
-    const requestUrl = `${serviceUrl}/v1/recommendation_pods?key=${apiKey}`;
+    const sectionParam = section ? `&section=${section}` : '';
+    const requestUrl = `${serviceUrl}/v1/recommendation_pods?key=${apiKey}${sectionParam}`.trim();
 
     Object.assign(headers, helpers.combineCustomHeaders(this.options, networkParameters));
 


### PR DESCRIPTION
This PR adds a parameters object to the getRecommendationsPod function so that an user can pass additional query params to the request.