### PR TITLE
[CI-3342] Pass section to getRecommendationPods

### DIFF
--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -642,6 +642,21 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
+    it.only('Should successfully send request when parameters are passed', (done) => {
+      const { recommendations } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      recommendations.getRecommendationPods({ section: 'Products' }).then((res) => {
+        expect(res).to.be.an('object');
+        expect(res).to.have.property('pods');
+        expect(res).to.have.property('total_count');
+
+        done();
+      });
+    });
+
     it('Should pass the correct custom headers passed in global networkParameters', (done) => {
       const { recommendations } = new ConstructorIO({
         ...validOptions,

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -629,6 +629,19 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
+    it('Should build requestURL with query params when parameters are passed', (done) => {
+      const { recommendations } = new ConstructorIO({
+        ...validOptions,
+        fetch: async (reqUrl) => ({ ok: true, json: async () => reqUrl }),
+      });
+
+      recommendations.getRecommendationPods({ section: 'test-section' }).then((res) => {
+        expect(res).to.contain('section=test-section');
+
+        done();
+      });
+    });
+
     it('Should pass the correct custom headers passed in global networkParameters', (done) => {
       const { recommendations } = new ConstructorIO({
         ...validOptions,

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -642,7 +642,7 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it.only('Should successfully send request when parameters are passed', (done) => {
+    it('Should successfully send request when parameters are passed', (done) => {
       const { recommendations } = new ConstructorIO({
         ...validOptions,
         fetch: fetchSpy,

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -1446,6 +1446,7 @@ class Catalog {
         'Content-Type': 'application/json',
         ...helpers.createAuthHeader(this.options),
       },
+      body: JSON.stringify({}),
       signal,
     }).then((response) => {
       if (response.ok) {

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -1443,10 +1443,8 @@ class Catalog {
     return fetch(requestUrl, {
       method: 'DELETE',
       headers: {
-        'Content-Type': 'application/json',
         ...helpers.createAuthHeader(this.options),
       },
-      body: JSON.stringify({}),
       signal,
     }).then((response) => {
       if (response.ok) {
@@ -1486,7 +1484,6 @@ class Catalog {
     return fetch(requestUrl, {
       method: 'DELETE',
       headers: {
-        'Content-Type': 'application/json',
         ...helpers.createAuthHeader(this.options),
       },
       signal,

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -219,18 +219,13 @@ class Recommendations {
     const url = `${serviceUrl}/v1/recommendation_pods`;
 
     // For backwards compatibility we allow only "networkParameters" to be passed, meaning "parameters" should be
-    // copied to networkParameters. However, since networkParameters is defaulted, in the new implementation it's
-    // possible a customer may pass only parameters and leave networkParams empty. Because of this (this is hacky) but
-    // we will check parameters for timeout/headers before moving params -> network params, since timeout is the only
-    // possible network field. Also, once all customers migrate to using both parameters we should remove this
-    let parsedParameters = parameters;
+    // copied to networkParameters. If both parameters and networkParameters are passed we leave them as is
     let parsedNetworkParameters = networkParameters;
-    if (!networkParameters && (parameters.timeout || parameters.headers)) {
-      parsedParameters = {};
+    if (parameters.timeout || parameters.headers) {
       parsedNetworkParameters = parameters;
     }
 
-    const { section } = parsedParameters;
+    const { section } = parameters;
 
     let queryParams = {
       key: apiKey,

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -221,11 +221,11 @@ class Recommendations {
     // For backwards compatibility we allow only "networkParameters" to be passed, meaning "parameters" should be
     // copied to networkParameters. However, since networkParameters is defaulted, in the new implementation it's
     // possible a customer may pass only parameters and leave networkParams empty. Because of this (this is hacky) but
-    // we will check parameters for timeout before moving params -> network params, since timeout is the only possible
-    // network field. Also, once all customers migrate to using both parameters we should remove this
+    // we will check parameters for timeout/headers before moving params -> network params, since timeout is the only
+    // possible network field. Also, once all customers migrate to using both parameters we should remove this
     let parsedParameters = parameters;
     let parsedNetworkParameters = networkParameters;
-    if (!networkParameters && parameters.timeout) {
+    if (!networkParameters && (parameters.timeout || parameters.headers)) {
       parsedParameters = {};
       parsedNetworkParameters = parameters;
     }


### PR DESCRIPTION
Pass section to getRecommendationPods through parameters.

To maintain backwards compatibility, parameters will be treated as networkParameters in some cases. This is until all customers migrate to using both parameters.