### PR TITLE
Add force and notification email to tar archive catalog methods

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -40,6 +40,8 @@
     "searchandized",
     "searchandizing",
     "patchdelta",
-    "searchabilities"
+    "searchabilities",
+    "forcesync",
+    "forcedelta"
   ]
 }

--- a/spec/src/modules/catalog/catalog-files.js
+++ b/spec/src/modules/catalog/catalog-files.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const { Duplex } = require('stream');
 const ConstructorIO = require('../../../../test/constructorio'); // eslint-disable-line import/extensions
+const helpers = require('../../../mocha.helpers');
 
 const nodeFetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
@@ -286,6 +287,11 @@ describe('ConstructorIO - Catalog', () => {
     });
 
     describe('replaceCatalogUsingTarArchive', () => {
+      const optionalParameters = {
+        force: true,
+        notificationEmail: 'test@constructor.io',
+      };
+
       it('Should replace a catalog of items, variations, and item groups using buffers', (done) => {
         const { catalog } = new ConstructorIO({
           ...validOptions,
@@ -304,6 +310,29 @@ describe('ConstructorIO - Catalog', () => {
         });
       });
 
+      it('Should replace a catalog of items, variations, and item groups using buffers and optional parameters (email and force)', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+
+        const data = {
+          tarArchive: tarArchiveBuffer,
+          section: 'Products',
+          ...optionalParameters,
+        };
+
+        catalog.replaceCatalogUsingTarArchive(data).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(requestedUrlParams).to.have.property('section').to.equal(data.section);
+          expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
+          expect(res).to.have.property('task_id');
+          expect(res).to.have.property('task_status_path');
+          done();
+        });
+      });
+
       it('Should replace a catalog of items, variations, and item groups using streams', (done) => {
         const { catalog } = new ConstructorIO({
           ...validOptions,
@@ -316,6 +345,29 @@ describe('ConstructorIO - Catalog', () => {
         };
 
         catalog.replaceCatalogUsingTarArchive(data).then((res) => {
+          expect(res).to.have.property('task_id');
+          expect(res).to.have.property('task_status_path');
+          done();
+        });
+      });
+
+      it('Should replace a catalog of items, variations, and item groups using streams and optional parameters (email and force)', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+
+        const data = {
+          tarArchive: tarArchiveStream,
+          section: 'Products',
+          ...optionalParameters,
+        };
+
+        catalog.replaceCatalogUsingTarArchive(data).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(requestedUrlParams).to.have.property('section').to.equal(data.section);
+          expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
           expect(res).to.have.property('task_id');
           expect(res).to.have.property('task_status_path');
           done();
@@ -546,6 +598,11 @@ describe('ConstructorIO - Catalog', () => {
     });
 
     describe('updateCatalogUsingTarArchive', () => {
+      const optionalParameters = {
+        force: true,
+        notificationEmail: 'test@constructor.io',
+      };
+
       it('Should update a catalog of items, variations, and item groups using buffers', (done) => {
         const { catalog } = new ConstructorIO({
           ...validOptions,
@@ -564,6 +621,30 @@ describe('ConstructorIO - Catalog', () => {
         });
       });
 
+      it('Should update a catalog of items, variations, and item groups using buffers and optional parameters (email and force)', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+
+        const data = {
+          tarArchive: tarArchiveBuffer,
+          section: 'Products',
+          ...optionalParameters,
+        };
+
+        catalog.updateCatalogUsingTarArchive(data).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(requestedUrlParams).to.have.property('section').to.equal(data.section);
+          expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
+
+          expect(res).to.have.property('task_id');
+          expect(res).to.have.property('task_status_path');
+          done();
+        });
+      });
+
       it('Should update a catalog of items, variations, and item groups using streams', (done) => {
         const { catalog } = new ConstructorIO({
           ...validOptions,
@@ -576,6 +657,29 @@ describe('ConstructorIO - Catalog', () => {
         };
 
         catalog.updateCatalogUsingTarArchive(data).then((res) => {
+          expect(res).to.have.property('task_id');
+          expect(res).to.have.property('task_status_path');
+          done();
+        });
+      });
+
+      it('Should update a catalog of items, variations, and item groups using streams and optional parameters (email and force)', (done) => {
+        const { catalog } = new ConstructorIO({
+          ...validOptions,
+          fetch: fetchSpy,
+        });
+
+        const data = {
+          tarArchive: tarArchiveStream,
+          section: 'Products',
+          ...optionalParameters,
+        };
+
+        catalog.updateCatalogUsingTarArchive(data).then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(requestedUrlParams).to.have.property('section').to.equal(data.section);
+          expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
           expect(res).to.have.property('task_id');
           expect(res).to.have.property('task_status_path');
           done();

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -2318,12 +2318,19 @@ class Catalog {
    */
   async replaceCatalogUsingTarArchive(parameters = {}, networkParameters = {}) {
     try {
+      const { force, notification_email, notificationEmail = notification_email } = parameters;
       const { fetch } = this.options;
       const apiKey = this.options && this.options.apiKey;
       const controller = new AbortController();
       const { signal } = controller;
       const { queryParams, formData } = await createQueryParamsAndFormData(parameters);
-      const formDataWithTarArchive = await addTarArchiveToFormData(parameters, formData, 'sync', apiKey);
+      const operation = force ? 'forcesync' : 'sync';
+      const formDataWithTarArchive = await addTarArchiveToFormData(parameters, formData, operation, apiKey);
+
+      if (notificationEmail) {
+        queryParams.notification_email = notificationEmail;
+      }
+
       const requestUrl = createCatalogUrl('catalog', this.options, queryParams);
       // Handle network timeout if specified
       helpers.applyNetworkTimeout(this.options, networkParameters, controller);
@@ -2367,12 +2374,20 @@ class Catalog {
    */
   async updateCatalogUsingTarArchive(parameters = {}, networkParameters = {}) {
     try {
+      const { force, notification_email, notificationEmail = notification_email } = parameters;
+
       const { fetch } = this.options;
       const apiKey = this.options && this.options.apiKey;
       const controller = new AbortController();
       const { signal } = controller;
       const { queryParams, formData } = await createQueryParamsAndFormData(parameters);
-      const formDataWithTarArchive = await addTarArchiveToFormData(parameters, formData, 'delta', apiKey);
+      const operation = force ? 'forcedelta' : 'delta';
+      const formDataWithTarArchive = await addTarArchiveToFormData(parameters, formData, operation, apiKey);
+
+      if (notificationEmail) {
+        queryParams.notification_email = notificationEmail;
+      }
+
       const requestUrl = createCatalogUrl('catalog', this.options, queryParams);
 
       // Handle network timeout if specified
@@ -2418,12 +2433,18 @@ class Catalog {
    */
   async patchCatalogUsingTarArchive(parameters = {}, networkParameters = {}) {
     try {
+      const { notification_email, notificationEmail = notification_email } = parameters;
       const { fetch } = this.options;
       const apiKey = this.options && this.options.apiKey;
       const controller = new AbortController();
       const { signal } = controller;
       const { queryParams, formData } = await createQueryParamsAndFormData(parameters);
       const formDataWithTarArchive = await addTarArchiveToFormData(parameters, formData, 'patchdelta', apiKey);
+
+      if (notificationEmail) {
+        queryParams.notification_email = notificationEmail;
+      }
+
       const requestUrl = createCatalogUrl('catalog', this.options, { ...queryParams, patch_delta: true });
 
       // Handle network timeout if specified


### PR DESCRIPTION
1. Added force flag to 'sync' and 'delta' to have 'forcesync' and 'forcedelta' for tarArchive methods
2. Added email notifications to tarArchive methods
3. Tested notification email and it's working
4. Added tests for requests with notification email and force flag


