### PR TITLE
[NO-REF] Fix typescript types for `File` stream in catalog functions

### DIFF
--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -1,3 +1,6 @@
+import type fs from 'fs';
+import type { Duplex } from 'stream';
+
 import {
   ConstructorClientOptions,
   Item,
@@ -167,9 +170,9 @@ export interface ReplaceCatalogParameters {
   section: string;
   notificationEmail?: string;
   force?: boolean;
-  items?: File;
-  variations?: File;
-  itemGroups?: File;
+  items?: File | fs.ReadStream | Duplex
+  variations?: File | fs.ReadStream | Duplex;
+  itemGroups?: File | fs.ReadStream | Duplex;
 }
 
 export interface UpdateCatalogParameters extends ReplaceCatalogParameters {}
@@ -179,16 +182,16 @@ export interface PatchCatalogParameters {
   notificationEmail?: string;
   force?: boolean;
   onMissing?: 'IGNORE' | 'CREATE' | 'FAIL';
-  items?: File;
-  variations?: File;
-  itemGroups?: File;
+  items?: File | fs.ReadStream | Duplex
+  variations?: File | fs.ReadStream | Duplex;
+  itemGroups?: File | fs.ReadStream | Duplex;
 }
 
 export interface ReplaceCatalogUsingTarArchiveParameters {
   section: string;
   notificationEmail?: string;
   force?: boolean;
-  tarArchive?: File;
+  tarArchive?: File | fs.ReadStream | Duplex;
 }
 
 export interface UpdateCatalogUsingTarArchiveParameters


### PR DESCRIPTION
Changes:
- Adds both `fs.ReadStream` and `Duplex` as possible stream types alongside `File`.

When consuming the node sdk from a node project, we won't have dom types available. In such case we'll most likely use node's native streams, such as `Redable`, `fs.ReadStream` and others.

E.g.
![image](https://github.com/user-attachments/assets/2c2478fa-5f77-4bdf-84bc-2142d87ca358)
