### PR TITLE
[CI-3858] Resolve body with `task_id` on mutating items and variations functions

### DIFF
--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -410,7 +410,7 @@ describe('ConstructorIO - Browse', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.fmt_options.hidden_facets).to.eql(hiddenFacets);
         expect(requestedUrlParams.fmt_options).to.have.property('hidden_facets').to.eql(hiddenFacets);
-        expect(res.response.facets[0]).to.have.property('name').to.eql('Brand');
+        expect(res.response.facets[1]).to.have.property('name').to.eql('Brand');
         done();
       });
     });

--- a/spec/src/modules/catalog/catalog-facet-configurations.js
+++ b/spec/src/modules/catalog/catalog-facet-configurations.js
@@ -48,19 +48,21 @@ describe('ConstructorIO - Catalog', () => {
     fetchSpy = null;
 
     // Add throttling between requests to avoid rate limiting
-    setTimeout(done, sendTimeout);
+    setTimeout(() => done(), sendTimeout);
   });
 
   describe('Facet Configurations', () => {
     const facetConfigurations = [];
 
-    after(async () => {
+    after(async function afterHook() {
       const { catalog } = new ConstructorIO({
         ...validOptions,
         fetch: fetchSpy,
       });
 
       // Clean up all the facet configurations that were created
+      // Increasing timeout, since cleanup is consistently taking longer than default 5 seconds
+      this.timeout(30000);
       for await (const facetConfig of facetConfigurations) {
         await catalog.removeFacetConfiguration(facetConfig);
       }

--- a/spec/src/modules/catalog/catalog-items.js
+++ b/spec/src/modules/catalog/catalog-items.js
@@ -81,9 +81,9 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceItems({ items }).then(() => {
+        catalog.createOrReplaceItems({ items }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(fetchSpy).to.have.been.called;
           expect(requestedUrlParams).to.have.property('key');
           expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
@@ -99,9 +99,9 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceItems({ items, ...optionalParameters }).then(() => {
+        catalog.createOrReplaceItems({ items, ...optionalParameters }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('section').to.equal(optionalParameters.section);
           expect(requestedUrlParams).to.have.property('force').to.equal(optionalParameters.force.toString());
           expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
@@ -188,7 +188,7 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceItems({ items }).then(done);
+        catalog.createOrReplaceItems({ items }).then(() => done());
         itemsToCleanup.push(...items);
       });
 
@@ -198,9 +198,10 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.updateItems({ items: updatedItems }).then(() => {
+        catalog.updateItems({ items: updatedItems }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(fetchSpy).to.have.been.called;
           expect(requestedUrlParams).to.have.property('key');
           expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
@@ -214,9 +215,10 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.updateItems({ items: updatedItems, ...optionalParameters }).then(() => {
+        catalog.updateItems({ items: updatedItems, ...optionalParameters }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('section').to.equal(optionalParameters.section);
           expect(requestedUrlParams).to.have.property('force').to.equal(optionalParameters.force.toString());
           expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
@@ -231,9 +233,10 @@ describe('ConstructorIO - Catalog', () => {
         });
         const onMissing = 'IGNORE';
 
-        catalog.updateItems({ items: updatedItems, onMissing }).then(() => {
+        catalog.updateItems({ items: updatedItems, onMissing }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('on_missing').to.equal(onMissing);
           done();
         });
@@ -337,7 +340,7 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceItems({ items }).then(done);
+        catalog.createOrReplaceItems({ items }).then(() => done());
         itemsToCleanup.push(...items);
       });
 
@@ -347,9 +350,10 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.deleteItems({ items: items.map((item) => ({ id: item.id })) }).then(() => {
+        catalog.deleteItems({ items: items.map((item) => ({ id: item.id })) }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(fetchSpy).to.have.been.called;
           expect(requestedUrlParams).to.have.property('key');
           expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
@@ -368,14 +372,16 @@ describe('ConstructorIO - Catalog', () => {
           notificationEmail: 'test@constructor.io',
         };
 
-        catalog.deleteItems({ items: items.map((item) => ({ id: item.id })), ...optionalParameters }).then(() => {
-          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        catalog.deleteItems({ items: items.map((item) => ({ id: item.id })), ...optionalParameters })
+          .then((response) => {
+            const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
-          expect(requestedUrlParams).to.have.property('section').to.equal(optionalParameters.section);
-          expect(requestedUrlParams).to.have.property('force').to.equal(optionalParameters.force.toString());
-          expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
-          done();
-        });
+            expect(response).to.have.property('task_id').to.be.a('number');
+            expect(requestedUrlParams).to.have.property('section').to.equal(optionalParameters.section);
+            expect(requestedUrlParams).to.have.property('force').to.equal(optionalParameters.force.toString());
+            expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
+            done();
+          });
       });
 
       it('Should return error when no items are provided', () => {
@@ -468,7 +474,7 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceItems({ items: mockItems }).then((done));
+        catalog.createOrReplaceItems({ items: mockItems }).then(() => done());
         itemsToCleanup.push(...mockItems);
       });
 

--- a/spec/src/modules/catalog/catalog-variations.js
+++ b/spec/src/modules/catalog/catalog-variations.js
@@ -83,7 +83,7 @@ describe('ConstructorIO - Catalog', () => {
     setTimeout(done, sendTimeout);
   });
 
-  describe.only('Variations', () => {
+  describe('Variations', () => {
     const item = createMockItem();
 
     describe('createOrReplaceVariations', () => {

--- a/spec/src/modules/catalog/catalog-variations.js
+++ b/spec/src/modules/catalog/catalog-variations.js
@@ -83,7 +83,7 @@ describe('ConstructorIO - Catalog', () => {
     setTimeout(done, sendTimeout);
   });
 
-  describe('Variations', () => {
+  describe.only('Variations', () => {
     const item = createMockItem();
 
     describe('createOrReplaceVariations', () => {
@@ -123,9 +123,10 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceVariations({ variations, ...optionalParameters }).then(() => {
+        catalog.createOrReplaceVariations({ variations, ...optionalParameters }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('section').to.equal(optionalParameters.section);
           expect(requestedUrlParams).to.have.property('force').to.equal(optionalParameters.force.toString());
           expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
@@ -213,7 +214,7 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceVariations({ variations }).then(done);
+        catalog.createOrReplaceVariations({ variations }).then(() => done());
         variationsToCleanup.push(...updatedVariations);
       });
 
@@ -223,10 +224,11 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.updateVariations({ variations: updatedVariations }).then(() => {
+        catalog.updateVariations({ variations: updatedVariations }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
           expect(fetchSpy).to.have.been.called;
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('key');
           expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
           done();
@@ -239,9 +241,10 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.updateVariations({ variations: updatedVariations, ...optionalParameters }).then(() => {
+        catalog.updateVariations({ variations: updatedVariations, ...optionalParameters }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('section').to.equal(optionalParameters.section);
           expect(requestedUrlParams).to.have.property('force').to.equal(optionalParameters.force.toString());
           expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
@@ -256,9 +259,10 @@ describe('ConstructorIO - Catalog', () => {
         });
         const onMissing = 'IGNORE';
 
-        catalog.updateVariations({ variations: updatedVariations, onMissing }).then(() => {
+        catalog.updateVariations({ variations: updatedVariations, onMissing }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('on_missing').to.equal(onMissing);
           done();
         });
@@ -353,7 +357,7 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceVariations({ variations, section: 'Products' }).then(done);
+        catalog.createOrReplaceVariations({ variations, section: 'Products' }).then(() => done());
       });
 
       it('Should resolve when removing multiple variations', (done) => {
@@ -363,14 +367,15 @@ describe('ConstructorIO - Catalog', () => {
         });
 
         variations.push(...variationsToCleanup);
-        catalog.deleteVariations({ variations: variations.map((variation) => ({ id: variation.id })), section: 'Products' }).then(() => {
+        catalog.deleteVariations({ variations: variations.map((variation) => ({ id: variation.id })), section: 'Products' }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
           expect(fetchSpy).to.have.been.called;
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('key');
           expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
 
-          catalog.deleteItems({ items: itemsToCleanup.map((variation) => ({ id: variation.id })), section: 'Products' }).then(done);
+          catalog.deleteItems({ items: itemsToCleanup.map((variation) => ({ id: variation.id })), section: 'Products' }).then(() => done());
         });
       });
 
@@ -385,13 +390,14 @@ describe('ConstructorIO - Catalog', () => {
         };
 
         variations.push(...variationsToCleanup);
-        catalog.deleteVariations({ variations: variations.map((variation) => ({ id: variation.id })), section: 'Products', ...optionalParameters }).then(() => {
+        catalog.deleteVariations({ variations: variations.map((variation) => ({ id: variation.id })), section: 'Products', ...optionalParameters }).then((response) => {
           const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
+          expect(response).to.have.property('task_id').to.be.a('number');
           expect(requestedUrlParams).to.have.property('force').to.equal(optionalParameters.force.toString());
           expect(requestedUrlParams).to.have.property('notification_email').to.equal(optionalParameters.notificationEmail);
 
-          catalog.deleteItems({ items: itemsToCleanup.map((variation) => ({ id: variation.id })), section: 'Products' }).then(done);
+          catalog.deleteItems({ items: itemsToCleanup.map((variation) => ({ id: variation.id })), section: 'Products' }).then(() => done());
         });
       });
 
@@ -475,7 +481,7 @@ describe('ConstructorIO - Catalog', () => {
           fetch: fetchSpy,
         });
 
-        catalog.createOrReplaceVariations({ variations, section: 'Products' }).then((done));
+        catalog.createOrReplaceVariations({ variations, section: 'Products' }).then(() => done());
         variationsToCleanup.push(...variations);
       });
 

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -210,7 +210,7 @@ class Catalog {
    *     ],
    * });
    */
-  createOrReplaceItems(parameters = {}, networkParameters = {}) {
+  async createOrReplaceItems(parameters = {}, networkParameters = {}) {
     let requestUrl;
     const { fetch } = this.options;
     const controller = new AbortController();
@@ -244,21 +244,27 @@ class Catalog {
     // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
-    return fetch(requestUrl, {
-      method: 'PUT',
-      body: JSON.stringify({ items }),
-      headers: {
-        'Content-Type': 'application/json',
-        ...helpers.createAuthHeader(this.options),
-      },
-      signal,
-    }).then((response) => {
+    try {
+      const response = await fetch(requestUrl, {
+        method: 'PUT',
+        body: JSON.stringify({ items }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...helpers.createAuthHeader(this.options),
+        },
+        signal,
+      });
+
+      const body = await response.json();
+
       if (response.ok) {
-        return Promise.resolve();
+        return Promise.resolve(body);
       }
 
       return helpers.throwHttpErrorFromResponse(new Error(), response);
-    });
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -293,7 +299,7 @@ class Catalog {
    *     section: 'Products',
    * });
    */
-  updateItems(parameters = {}, networkParameters = {}) {
+  async updateItems(parameters = {}, networkParameters = {}) {
     let requestUrl;
     const { fetch } = this.options;
     const controller = new AbortController();
@@ -336,21 +342,26 @@ class Catalog {
     // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
-    return fetch(requestUrl, {
-      method: 'PATCH',
-      body: JSON.stringify({ items }),
-      headers: {
-        'Content-Type': 'application/json',
-        ...helpers.createAuthHeader(this.options),
-      },
-      signal,
-    }).then((response) => {
+    try {
+      const response = await fetch(requestUrl, {
+        method: 'PATCH',
+        body: JSON.stringify({ items }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...helpers.createAuthHeader(this.options),
+        },
+        signal,
+      });
+
       if (response.ok) {
-        return Promise.resolve();
+        const body = await response.json();
+        return Promise.resolve(body);
       }
 
       return helpers.throwHttpErrorFromResponse(new Error(), response);
-    });
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -375,7 +386,7 @@ class Catalog {
    *     section: 'Products',
    * });
    */
-  deleteItems(parameters = {}, networkParameters = {}) {
+  async deleteItems(parameters = {}, networkParameters = {}) {
     let requestUrl;
     const { fetch } = this.options;
     const controller = new AbortController();
@@ -409,21 +420,26 @@ class Catalog {
     // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
-    return fetch(requestUrl, {
-      method: 'DELETE',
-      body: JSON.stringify({ items }),
-      headers: {
-        'Content-Type': 'application/json',
-        ...helpers.createAuthHeader(this.options),
-      },
-      signal,
-    }).then((response) => {
+    try {
+      const response = await fetch(requestUrl, {
+        method: 'DELETE',
+        body: JSON.stringify({ items }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...helpers.createAuthHeader(this.options),
+        },
+        signal,
+      });
+
       if (response.ok) {
-        return Promise.resolve();
+        const body = await response.json();
+        return Promise.resolve(body);
       }
 
       return helpers.throwHttpErrorFromResponse(new Error(), response);
-    });
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -534,7 +550,7 @@ class Catalog {
    *     section: 'Products',
    * });
    */
-  createOrReplaceVariations(parameters = {}, networkParameters = {}) {
+  async createOrReplaceVariations(parameters = {}, networkParameters = {}) {
     let requestUrl;
     const { fetch } = this.options;
     const controller = new AbortController();
@@ -568,21 +584,26 @@ class Catalog {
     // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
-    return fetch(requestUrl, {
-      method: 'PUT',
-      body: JSON.stringify({ variations }),
-      headers: {
-        'Content-Type': 'application/json',
-        ...helpers.createAuthHeader(this.options),
-      },
-      signal,
-    }).then((response) => {
+    try {
+      const response = await fetch(requestUrl, {
+        method: 'PUT',
+        body: JSON.stringify({ variations }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...helpers.createAuthHeader(this.options),
+        },
+        signal,
+      });
+
       if (response.ok) {
-        return Promise.resolve();
+        const body = await response.json();
+        return Promise.resolve(body);
       }
 
       return helpers.throwHttpErrorFromResponse(new Error(), response);
-    });
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -618,7 +639,7 @@ class Catalog {
    *     section: 'Products',
    * });
    */
-  updateVariations(parameters = {}, networkParameters = {}) {
+  async updateVariations(parameters = {}, networkParameters = {}) {
     let requestUrl;
     const { fetch } = this.options;
     const controller = new AbortController();
@@ -661,21 +682,26 @@ class Catalog {
     // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
-    return fetch(requestUrl, {
-      method: 'PATCH',
-      body: JSON.stringify({ variations }),
-      headers: {
-        'Content-Type': 'application/json',
-        ...helpers.createAuthHeader(this.options),
-      },
-      signal,
-    }).then((response) => {
+    try {
+      const response = await fetch(requestUrl, {
+        method: 'PATCH',
+        body: JSON.stringify({ variations }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...helpers.createAuthHeader(this.options),
+        },
+        signal,
+      });
+
       if (response.ok) {
-        return Promise.resolve();
+        const body = await response.json();
+        return Promise.resolve(body);
       }
 
       return helpers.throwHttpErrorFromResponse(new Error(), response);
-    });
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -700,7 +726,7 @@ class Catalog {
    *     section: 'Products',
    * });
    */
-  deleteVariations(parameters = {}, networkParameters = {}) {
+  async deleteVariations(parameters = {}, networkParameters = {}) {
     let requestUrl;
     const { fetch } = this.options;
     const controller = new AbortController();
@@ -734,21 +760,26 @@ class Catalog {
     // Handle network timeout if specified
     helpers.applyNetworkTimeout(this.options, networkParameters, controller);
 
-    return fetch(requestUrl, {
-      method: 'DELETE',
-      body: JSON.stringify({ variations }),
-      headers: {
-        'Content-Type': 'application/json',
-        ...helpers.createAuthHeader(this.options),
-      },
-      signal,
-    }).then((response) => {
+    try {
+      const response = await fetch(requestUrl, {
+        method: 'DELETE',
+        body: JSON.stringify({ variations }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...helpers.createAuthHeader(this.options),
+        },
+        signal,
+      });
+
       if (response.ok) {
-        return Promise.resolve();
+        const body = await response.json();
+        return Promise.resolve(body);
       }
 
       return helpers.throwHttpErrorFromResponse(new Error(), response);
-    });
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -255,9 +255,9 @@ class Catalog {
         signal,
       });
 
-      const body = await response.json();
-
       if (response.ok) {
+        const body = await response.json();
+
         return Promise.resolve(body);
       }
 

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -272,6 +272,12 @@ export interface PatchSearchabilitiesParameters {
   section?: string;
 }
 
+interface CatalogMutationResponse {
+  task_id: string;
+  task_status_path: string;
+  [key: string]: any;
+}
+
 declare class Catalog {
   constructor(options: ConstructorClientOptions);
 
@@ -280,17 +286,17 @@ declare class Catalog {
   createOrReplaceItems(
     parameters: CreateOrReplaceItemsParameters,
     networkParameters?: NetworkParameters
-  ): Promise<void>;
+  ): Promise<CatalogMutationResponse>;
 
   updateItems(
     parameters: UpdateItemsParameters,
     networkParameters?: NetworkParameters
-  ): Promise<void>;
+  ): Promise<CatalogMutationResponse>;
 
   deleteItems(
     parameters: DeleteItemsParameters,
     networkParameters?: NetworkParameters
-  ): Promise<void>;
+  ): Promise<CatalogMutationResponse>;
 
   retrieveItems(
     parameters: RetrieveItemsParameters,
@@ -300,17 +306,17 @@ declare class Catalog {
   createOrReplaceVariations(
     parameters: CreateOrReplaceVariationsParameters,
     networkParameters?: NetworkParameters
-  ): Promise<void>;
+  ): Promise<CatalogMutationResponse>;
 
   updateVariations(
     parameters: UpdateVariationsParameters,
     networkParameters?: NetworkParameters
-  ): Promise<void>;
+  ): Promise<CatalogMutationResponse>;
 
   deleteVariations(
     parameters: DeleteVariationsParameters,
     networkParameters?: NetworkParameters
-  ): Promise<void>;
+  ): Promise<CatalogMutationResponse>;
 
   retrieveVariations(
     parameters: RetrieveVariationsParameters,
@@ -479,56 +485,32 @@ declare class Catalog {
   replaceCatalog(
     parameters: ReplaceCatalogParameters,
     networkParameters?: NetworkParameters
-  ): Promise<{
-    task_id: string;
-    task_status_path: string;
-    [key: string]: any;
-  }>;
+  ): Promise<CatalogMutationResponse>;
 
   updateCatalog(
     parameters: UpdateCatalogParameters,
     networkParameters?: NetworkParameters
-  ): Promise<{
-    task_id: string;
-    task_status_path: string;
-    [key: string]: any;
-  }>;
+  ): Promise<CatalogMutationResponse>;
 
   patchCatalog(
     parameters: PatchCatalogParameters,
     networkParameters?: NetworkParameters
-  ): Promise<{
-    task_id: string;
-    task_status_path: string;
-    [key: string]: any;
-  }>;
+  ): Promise<CatalogMutationResponse>;
 
   replaceCatalogUsingTarArchive(
     parameters: ReplaceCatalogUsingTarArchiveParameters,
     networkParameters?: NetworkParameters
-  ): Promise<{
-    task_id: string;
-    task_status_path: string;
-    [key: string]: any;
-  }>;
+  ): Promise<CatalogMutationResponse>;
 
   updateCatalogUsingTarArchive(
     parameters: UpdateCatalogUsingTarArchiveParameters,
     networkParameters?: NetworkParameters
-  ): Promise<{
-    task_id: string;
-    task_status_path: string;
-    [key: string]: any;
-  }>;
+  ): Promise<CatalogMutationResponse>;
 
   patchCatalogUsingTarArchive(
     parameters: PatchCatalogUsingTarArchiveParameters,
     networkParameters?: NetworkParameters
-  ): Promise<{
-    task_id: string;
-    task_status_path: string;
-    [key: string]: any;
-  }>;
+  ): Promise<CatalogMutationResponse>;
 
   addFacetConfiguration(
     parameters: FacetConfiguration,


### PR DESCRIPTION
- Update the following mutating functions to return the API call response body instead of resolving an empty promise:
  - `createOrReplaceItems`
  - `updateItems`
  - `deleteItems`
  - `createOrReplaceVariations`
  - `updateVariations`
  - `deleteVariations`
- Fix broken tests related to `getBrowseResults` and `Facet Configurations` cleanup hook
