### PR TITLE
Update quizzes answers parameter skippable documentation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -43,6 +43,7 @@
     "searchabilities",
     "forcesync",
     "forcedelta",
-    "forcepatchdelta"
+    "forcepatchdelta",
+    "skippable"
   ]
 }

--- a/src/modules/quizzes.js
+++ b/src/modules/quizzes.js
@@ -108,7 +108,7 @@ class Quizzes {
    * @description Retrieve quiz question from Constructor.io API
    * @param {string} quizId - The identifier of the quiz
    * @param {string} parameters - Additional parameters to refine result set
-   * @param {array} parameters.answers - An array of answers in the format [[1,2],[1], ["true"], ["seen"], [""]]. Based on the question type, answers should either be an integer, "true", "false", "seen" or empty string ("") if skipped
+   * @param {array} parameters.answers - An array of answers in the format [[1,2],[1], ["true"], ["seen"], [""]]. Based on the question type, answers should either be an integer, "true", "false", "seen" or empty string ("") if the question is skippable: i.e., configured as `is_skippable:true`.
    * @param {string} [parameters.section] - Product catalog section
    * @param {string} [parameters.quizVersionId] - Version identifier for the quiz. Version ID will be returned with the first request and it should be passed with subsequent requests. More information can be found [here]{@link https://docs.constructor.com/reference/configuration-quizzes}
    * @param {string} [parameters.quizSessionId] - Session identifier for the quiz. Session ID will be returned with the first request and it should be passed with subsequent requests. More information can be found [here]{@link https://docs.constructor.com/reference/configuration-quizzes}
@@ -186,7 +186,7 @@ class Quizzes {
    * @description Retrieve quiz recommendation and filter expression from Constructor.io API
    * @param {string} quizId - The identifier of the quiz
    * @param {string} parameters - Additional parameters to refine result set
-   * @param {array} parameters.answers - An array of answers in the format [[1,2],[1], ["true"], ["seen"], [""]]. Based on the question type, answers should either be an integer, "true", "false", "seen" or empty string ("") if skipped
+   * @param {array} parameters.answers - An array of answers in the format [[1,2],[1], ["true"], ["seen"], [""]]. Based on the question type, answers should either be an integer, "true", "false", "seen" or empty string ("") if the question is skippable: i.e., configured as `is_skippable:true`.
    * @param {string} [parameters.section] - Product catalog section
    * @param {string} [parameters.quizVersionId] - Version identifier for the quiz. Version ID will be returned with the first request and it should be passed with subsequent requests. More information can be found [here]{@link https://docs.constructor.com/reference/configuration-quizzes}
    * @param {string} [parameters.quizSessionId] - Session identifier for the quiz. Session ID will be returned with the first request and it should be passed with subsequent requests. More information can be found [here]{@link https://docs.constructor.com/reference/configuration-quizzes}


### PR DESCRIPTION
It can be confusing that passing an empty string would allow skipping any question

**Before:**

- empty string ("") if skipped

**After:**

-  empty string ("") if the question is skippable: i.e., configured as `is_skippable: true`.