### PR TITLE
Handle text API responses

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -8143,6 +8143,33 @@ describe('ConstructorIO - Tracker', () => {
       });
     });
 
+    it('Should receive an error message when rate limited (429)', (done) => {
+      // Create a mock response for 429 error
+      fetchSpy = sinon.spy(() => Promise.resolve({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: new Map([['content-type', 'application/text']]),
+        text: () => Promise.resolve('Too many requests'),
+      }));
+
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      tracker.trackInputFocus(userParameters);
+
+      tracker.on('error', (response) => {
+        expect(response).to.have.property('url');
+        expect(response).to.have.property('method');
+        expect(response).to.have.property('message');
+        expect(response.message).to.not.be.undefined;
+        expect(response.message).to.equal('Too many requests');
+        done();
+      });
+    });
+
     it('Should receive an error message when making a request to an invalid endpoint', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -8149,7 +8149,7 @@ describe('ConstructorIO - Tracker', () => {
         ok: false,
         status: 429,
         statusText: 'Too Many Requests',
-        headers: new Map([['content-type', 'application/text']]),
+        headers: new Map([['content-type', 'text/plain']]),
         text: () => Promise.resolve('Too many requests'),
       }));
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -139,6 +139,7 @@ function send(url, userParameters, networkParameters, method = 'GET', body = {})
 
   if (request) {
     const instance = this;
+    const emitError = helpers.getEmitError(instance, { url, method });
 
     request.then((response) => {
       // Request was successful, and returned a 2XX status code
@@ -156,41 +157,21 @@ function send(url, userParameters, networkParameters, method = 'GET', body = {})
 
         if (contentType.includes('application/json')) {
           response.json().then((json) => {
-            instance.eventemitter.emit('error', {
-              url,
-              method,
-              message: json && json.message,
-            });
+            emitError(json && json.message);
           }).catch((error) => {
-            instance.eventemitter.emit('error', {
-              url,
-              method,
-              message: error.type,
-            });
+            emitError(error.type);
           });
         } else {
           // If not JSON, fallback to text
           response.text().then((text) => {
-            instance.eventemitter.emit('error', {
-              url,
-              method,
-              message: text || 'Unknown error message',
-            });
+            emitError(text || 'Unknown error message');
           }).catch((error) => {
-            instance.eventemitter.emit('error', {
-              url,
-              method,
-              message: `Error reading text: ${error.message}`,
-            });
+            emitError(`Error reading text: ${error.message}`);
           });
         }
       }
     }).catch((error) => {
-      instance.eventemitter.emit('error', {
-        url,
-        method,
-        message: error.toString(),
-      });
+      emitError(error.toString());
     });
   }
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -134,6 +134,12 @@ const utils = {
 
     return url;
   },
+
+  getEmitError(instance, { url, method }) {
+    return function emitError(message) {
+      instance.eventemitter.emit('error', { url, method, message });
+    };
+  },
 };
 
 module.exports = utils;


### PR DESCRIPTION
Why?

- Focus API events return a text response for the 429 errors
- We only handle JSON response types
- This PR adds support for handling text responses as well by checking the `Content-Type` header before processing the response

The screenshot shows an example of the API response for 429 response

<img width="1008" alt="Screenshot 2025-04-15 at 9 47 44 PM" src="https://github.com/user-attachments/assets/d44ef737-400f-4e8b-9d3d-0e68083e5fe1" />

<img width="1014" alt="Screenshot 2025-04-15 at 9 47 28 PM" src="https://github.com/user-attachments/assets/4980c31a-c934-4045-8766-60a5f0c7e920" />
