### PR TITLE
[CDX-441] Add support for origin_referrer in SABR

### DIFF
--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -337,7 +337,7 @@ describe('ConstructorIO - Autocomplete', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
         done();
-      });
+      }).catch(done);
     });
 
     it('Should return a response with a valid query and security token', (done) => {

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -322,6 +322,24 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
+    it('Should return a response with a valid query and origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { autocomplete } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      autocomplete.getAutocompleteResults(query, {}, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('sections').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      });
+    });
+
     it('Should return a response with a valid query and security token', (done) => {
       const securityToken = 'cio-node-test';
       const { autocomplete } = new ConstructorIO({

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -976,6 +976,24 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should return a response with valid ids and origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseResultsForItemIds(ids, null, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      }).catch(done);
+    });
+
     it('Should return a response with valid ids and page', (done) => {
       const page = 1;
       const { browse } = new ConstructorIO({
@@ -1444,6 +1462,24 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should return a response with valid ids and origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseGroups({}, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      }).catch(done);
+    });
+
     it('Should return a response with valid ids and additional filters', (done) => {
       const filters = { group_id: ['drill_collection'] };
       const { browse } = new ConstructorIO({
@@ -1755,6 +1791,24 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should return a response with origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseFacets({}, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      }).catch(done);
+    });
+
     it('Should combine custom headers from function networkParameters and global networkParameters', (done) => {
       const { browse } = new ConstructorIO({
         ...validOptions,
@@ -1946,6 +2000,24 @@ describe('ConstructorIO - Browse', () => {
         expect(requestedHeaders).to.have.property('User-Agent').to.equal('test2');
         done();
       });
+    });
+
+    it('Should return a response with origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseFacetOptions(facetName, {}, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      }).catch(done);
     });
 
     it('Should combine custom headers from function networkParameters and global networkParameters', (done) => {

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -285,6 +285,24 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should return a response with a valid filterName, filterValue, and origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { browse } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseResults(filterName, filterValue, {}, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      });
+    });
+
     it('Should return a response with a valid filterName, filterValue, and security token', (done) => {
       const securityToken = 'cio-node-test';
       const { browse } = new ConstructorIO({

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -300,7 +300,7 @@ describe('ConstructorIO - Browse', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
         done();
-      });
+      }).catch(done);
     });
 
     it('Should return a response with a valid filterName, filterValue, and security token', (done) => {

--- a/spec/src/modules/quizzes.js
+++ b/spec/src/modules/quizzes.js
@@ -169,7 +169,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizNextQuestion(validQuizId, { answers: validAnswers }).then((res) => {
+      return quizzes.getQuizNextQuestion(validQuizId, { answers: validAnswers, quizSessionId }).then((res) => {
         expect(res).to.have.property('quiz_version_id').to.be.an('string');
         expect(res).to.have.property('quiz_session_id').to.be.an('string');
         expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
@@ -184,11 +184,19 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizNextQuestion(validQuizId, { answers: validAnswers, skipTracking: true }).then(() => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+      return quizzes
+        .getQuizNextQuestion(validQuizId, {
+          answers: validAnswers,
+          skipTracking: true,
+          quizSessionId,
+        })
+        .then(() => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
-        expect(requestedUrlParams).to.have.property('skip_tracking').to.equal('true');
-      });
+          expect(requestedUrlParams)
+            .to.have.property('skip_tracking')
+            .to.equal('true');
+        });
     });
 
     it('Should be rejected if an invalid quizId is provided', () => {
@@ -266,23 +274,29 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers }, { clientId, sessionId }).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+      return quizzes
+        .getQuizResults(
+          validQuizId,
+          { answers: validAnswers, quizSessionId },
+          { clientId, sessionId },
+        )
+        .then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        expect(res).to.have.property('quiz_version_id').to.be.an('string');
-        expect(res).to.have.property('quiz_session_id').to.be.an('string');
-        expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
-        expect(fetchSpy).to.have.been.called;
-        expect(requestedUrlParams).to.have.property('key');
-        expect(requestedUrlParams).to.have.property('i');
-        expect(requestedUrlParams).to.have.property('s');
-        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
-        expect(requestedUrlParams).to.have.property('_dt');
-      });
+          expect(res).to.have.property('request').to.be.an('object');
+          expect(res).to.have.property('response').to.be.an('object');
+          expect(res).to.have.property('result_id').to.be.an('string');
+          expect(res.response).to.have.property('results').to.be.an('array');
+          expect(res).to.have.property('quiz_version_id').to.be.an('string');
+          expect(res).to.have.property('quiz_session_id').to.be.an('string');
+          expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
+          expect(fetchSpy).to.have.been.called;
+          expect(requestedUrlParams).to.have.property('key');
+          expect(requestedUrlParams).to.have.property('i');
+          expect(requestedUrlParams).to.have.property('s');
+          expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
+          expect(requestedUrlParams).to.have.property('_dt');
+        });
     });
 
     it('Should return a result given valid API key, answers and page parameters', () => {
@@ -292,7 +306,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, page }).then((res) => {
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, page, quizSessionId }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -313,18 +327,29 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, resultsPerPage }).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+      return quizzes
+        .getQuizResults(validQuizId, {
+          answers: validAnswers,
+          resultsPerPage,
+          quizSessionId,
+        })
+        .then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        expect(res).to.have.property('quiz_version_id').to.be.an('string');
-        expect(res).to.have.property('quiz_session_id').to.be.an('string');
-        expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
-        expect(requestedUrlParams).to.have.property('num_results_per_page').to.equal(resultsPerPage);
-      });
+          expect(res).to.have.property('request').to.be.an('object');
+          expect(res).to.have.property('response').to.be.an('object');
+          expect(res).to.have.property('result_id').to.be.an('string');
+          expect(res.response).to.have.property('results').to.be.an('array');
+          expect(res).to.have.property('quiz_version_id').to.be.an('string');
+          expect(res).to.have.property('quiz_session_id').to.be.an('string');
+          expect(res)
+            .to.have.property('quiz_id')
+            .to.be.an('string')
+            .to.equal(validQuizId);
+          expect(requestedUrlParams)
+            .to.have.property('num_results_per_page')
+            .to.equal(resultsPerPage);
+        });
     });
 
     it('Should return a result given valid API key, answers and filters parameters', () => {
@@ -334,7 +359,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, filters }).then((res) => {
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, filters, quizSessionId }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -355,7 +380,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, section }).then((res) => {
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, section, quizSessionId }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -375,7 +400,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers }).then((initialResponse) => {
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, quizSessionId }).then((initialResponse) => {
         const { quiz_version_id: quizVersionId } = initialResponse;
 
         // eslint-disable-next-line max-len
@@ -402,7 +427,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers }, { userId }).then((res) => {
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, quizSessionId }, { userId }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -423,7 +448,7 @@ describe('ConstructorIO - Quizzes', () => {
         fetch: fetchSpy,
       });
 
-      return quizzes.getQuizResults(validQuizId, { answers: validAnswers }, { segments }).then((res) => {
+      return quizzes.getQuizResults(validQuizId, { answers: validAnswers, quizSessionId }, { segments }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');

--- a/spec/src/modules/quizzes.js
+++ b/spec/src/modules/quizzes.js
@@ -145,6 +145,24 @@ describe('ConstructorIO - Quizzes', () => {
       });
     });
 
+    it('Should return a result provided a valid apiKey, quizId and origin referrer', () => {
+      const originReferrer = 'https://localhost';
+      const { quizzes } = new ConstructorIO({
+        apiKey: quizApiKey,
+        fetch: fetchSpy,
+      });
+
+      return quizzes.getQuizNextQuestion(validQuizId, {}, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('quiz_version_id').to.be.an('string');
+        expect(res).to.have.property('quiz_session_id').to.be.an('string');
+        expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
+        expect(res).to.have.property('next_question').to.be.an('object');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+      });
+    });
+
     it('Should return result given answers parameter', () => {
       const { quizzes } = new ConstructorIO({
         apiKey: quizApiKey,
@@ -417,6 +435,38 @@ describe('ConstructorIO - Quizzes', () => {
         expect(res).to.have.property('quiz_id').to.be.an('string').to.equal(validQuizId);
         expect(requestedUrlParams).to.have.property('us').to.deep.equal(segments);
       });
+    });
+
+    it('Should return a result provided a valid apiKey, quizId and origin referrer', () => {
+      const originReferrer = 'https://localhost';
+      const { quizzes } = new ConstructorIO({
+        apiKey: quizApiKey,
+        fetch: fetchSpy,
+      });
+
+      return quizzes
+        .getQuizResults(
+          validQuizId,
+          { answers: validAnswers, quizSessionId },
+          { originReferrer },
+        )
+        .then((res) => {
+          const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+          expect(res).to.have.property('request').to.be.an('object');
+          expect(res).to.have.property('response').to.be.an('object');
+          expect(res).to.have.property('result_id').to.be.an('string');
+          expect(res.response).to.have.property('results').to.be.an('array');
+          expect(res).to.have.property('quiz_version_id').to.be.an('string');
+          expect(res).to.have.property('quiz_session_id').to.be.an('string');
+          expect(res)
+            .to.have.property('quiz_id')
+            .to.be.an('string')
+            .to.equal(validQuizId);
+          expect(requestedUrlParams)
+            .to.have.property('origin_referrer')
+            .to.equal(originReferrer);
+        });
     });
 
     it('Should be rejected if no quizId is provided', () => {

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -315,6 +315,24 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
+    it('Should return a response with valid itemIds, result_id, and origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { recommendations } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      recommendations.getRecommendations(podId, { itemIds }, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      });
+    });
+
     it('Should return a response with a valid query, section, and security token', (done) => {
       const securityToken = 'cio-node-test';
       const { recommendations } = new ConstructorIO({

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -330,7 +330,7 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
         done();
-      });
+      }).catch(done);
     });
 
     it('Should return a response with a valid query, section, and security token', (done) => {

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -316,7 +316,7 @@ describe('ConstructorIO - Search', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
         done();
-      });
+      }).catch(done);
     });
 
     it('Should return a response with a valid query, section, and security token', (done) => {
@@ -1026,7 +1026,7 @@ describe('ConstructorIO - Search', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
         done();
-      });
+      }).catch(done);
     });
 
     it('Should return a response with a valid query, section, and security token', (done) => {

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -301,6 +301,24 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
+    it('Should return a response with a valid query, section, and origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { search } = new ConstructorIO({
+        ...validOptions,
+        fetch: fetchSpy,
+      });
+
+      search.getSearchResults(query, { section }, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
+        done();
+      });
+    });
+
     it('Should return a response with a valid query, section, and security token', (done) => {
       const securityToken = 'cio-node-test';
       const { search } = new ConstructorIO({
@@ -989,6 +1007,24 @@ describe('ConstructorIO - Search', () => {
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(requestedHeaders).to.have.property('X-Forwarded-For').to.equal(userIp);
+        done();
+      });
+    });
+
+    it('Should return a response with a valid query, section, and origin referrer', (done) => {
+      const originReferrer = 'https://localhost';
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      search.getVoiceSearchResults(voiceSearchQuery, { section }, { originReferrer }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('origin_referrer').to.equal(originReferrer);
         done();
       });
     });

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -46,7 +46,7 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
     queryParams.ui = String(userId);
   }
 
-  // Pull origin referrer from options
+  // Pull origin referrer from userParameters
   if (originReferrer) {
     queryParams.origin_referrer = originReferrer;
   }

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -47,7 +47,7 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
   }
 
   // Pull origin referrer from userParameters
-  if (originReferrer) {
+  if (originReferrer && typeof originReferrer === 'string') {
     queryParams.origin_referrer = originReferrer;
   }
 

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -16,6 +16,7 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
     userId,
     segments,
     testCells,
+    originReferrer,
   } = userParameters;
   let queryParams = { c: version };
 
@@ -43,6 +44,11 @@ function createAutocompleteUrl(query, parameters, userParameters, options) {
   // Pull user id from options and ensure string
   if (userId) {
     queryParams.ui = String(userId);
+  }
+
+  // Pull origin referrer from options
+  if (originReferrer) {
+    queryParams.origin_referrer = originReferrer;
   }
 
   if (parameters) {
@@ -155,6 +161,7 @@ class Autocomplete {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -131,7 +131,7 @@ function createQueryParams(parameters, userParameters, options) {
     queryParams.ui = String(userId);
   }
 
-  // Pull origin referrer from options
+  // Pull origin referrer from userParameters
   if (originReferrer) {
     queryParams.origin_referrer = originReferrer;
   }

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -132,7 +132,7 @@ function createQueryParams(parameters, userParameters, options) {
   }
 
   // Pull origin referrer from userParameters
-  if (originReferrer) {
+  if (originReferrer && typeof originReferrer === 'string') {
     queryParams.origin_referrer = originReferrer;
   }
 

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -16,6 +16,7 @@ function createQueryParams(parameters, userParameters, options) {
     userId,
     segments,
     testCells,
+    originReferrer,
   } = userParameters;
   let queryParams = { c: version };
 
@@ -128,6 +129,11 @@ function createQueryParams(parameters, userParameters, options) {
   // Pull user id from options and ensure string
   if (userId) {
     queryParams.ui = String(userId);
+  }
+
+  // Pull origin referrer from options
+  if (originReferrer) {
+    queryParams.origin_referrer = originReferrer;
   }
 
   queryParams._dt = Date.now();
@@ -265,6 +271,7 @@ class Browse {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request
@@ -350,6 +357,7 @@ class Browse {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request
@@ -417,6 +425,7 @@ class Browse {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request
@@ -480,6 +489,7 @@ class Browse {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request
@@ -540,6 +550,7 @@ class Browse {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request

--- a/src/modules/quizzes.js
+++ b/src/modules/quizzes.js
@@ -36,7 +36,7 @@ function createQuizUrl(quizId, parameters, userParameters, options, path) {
   }
 
   // Pull origin referrer from userParameters
-  if (originReferrer) {
+  if (originReferrer && typeof originReferrer === 'string') {
     queryParams.origin_referrer = originReferrer;
   }
 

--- a/src/modules/quizzes.js
+++ b/src/modules/quizzes.js
@@ -35,7 +35,7 @@ function createQuizUrl(quizId, parameters, userParameters, options, path) {
     queryParams.ui = String(userId);
   }
 
-  // Pull origin referrer from options
+  // Pull origin referrer from userParameters
   if (originReferrer) {
     queryParams.origin_referrer = originReferrer;
   }

--- a/src/modules/quizzes.js
+++ b/src/modules/quizzes.js
@@ -15,6 +15,7 @@ function createQuizUrl(quizId, parameters, userParameters, options, path) {
     clientId,
     userId,
     segments,
+    originReferrer,
   } = userParameters;
   const serviceUrl = 'https://quizzes.cnstrc.com';
   let queryParams = { c: version };
@@ -32,6 +33,11 @@ function createQuizUrl(quizId, parameters, userParameters, options, path) {
   // Pull user id from options and ensure string
   if (userId) {
     queryParams.ui = String(userId);
+  }
+
+  // Pull origin referrer from options
+  if (originReferrer) {
+    queryParams.origin_referrer = originReferrer;
   }
 
   // Validate quiz id is provided
@@ -124,6 +130,7 @@ class Quizzes {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request
@@ -207,6 +214,7 @@ class Quizzes {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -39,7 +39,7 @@ function createRecommendationsUrl(podId, parameters, userParameters, options) {
   }
 
   // Pull origin referrer from userParameters
-  if (originReferrer) {
+  if (originReferrer && typeof originReferrer === 'string') {
     queryParams.origin_referrer = originReferrer;
   }
 

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -15,6 +15,7 @@ function createRecommendationsUrl(podId, parameters, userParameters, options) {
     clientId,
     userId,
     segments,
+    originReferrer,
   } = userParameters;
   let queryParams = { c: version };
 
@@ -35,6 +36,11 @@ function createRecommendationsUrl(podId, parameters, userParameters, options) {
   // Pull user id from options and ensure string
   if (userId) {
     queryParams.ui = String(userId);
+  }
+
+  // Pull origin referrer from options
+  if (originReferrer) {
+    queryParams.origin_referrer = originReferrer;
   }
 
   if (parameters) {
@@ -147,6 +153,7 @@ class Recommendations {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -38,7 +38,7 @@ function createRecommendationsUrl(podId, parameters, userParameters, options) {
     queryParams.ui = String(userId);
   }
 
-  // Pull origin referrer from options
+  // Pull origin referrer from userParameters
   if (originReferrer) {
     queryParams.origin_referrer = originReferrer;
   }

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -18,6 +18,7 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
     userId,
     segments,
     testCells,
+    originReferrer,
   } = userParameters;
   let queryParams = { c: version };
 
@@ -45,6 +46,11 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
   // Pull user id from options and ensure string
   if (userId) {
     queryParams.ui = String(userId);
+  }
+
+  // Pull origin referrer from options
+  if (originReferrer) {
+    queryParams.origin_referrer = originReferrer;
   }
 
   if (parameters) {
@@ -186,6 +192,7 @@ class Search {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request
@@ -288,6 +295,7 @@ class Search {
    * @param {string} [userParameters.userId] - User ID, utilized to personalize results
    * @param {string[]} [userParameters.segments] - User segments
    * @param {object} [userParameters.testCells] - User test cells
+   * @param {string} [userParameters.originReferrer] - Client page URL (including path)
    * @param {string} [userParameters.userIp] - Origin user IP, from client
    * @param {string} [userParameters.userAgent] - Origin user agent, from client
    * @param {object} [networkParameters] - Parameters relevant to the network request

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -48,7 +48,7 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
     queryParams.ui = String(userId);
   }
 
-  // Pull origin referrer from options
+  // Pull origin referrer from userParameters
   if (originReferrer) {
     queryParams.origin_referrer = originReferrer;
   }

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -49,7 +49,7 @@ function createSearchUrl(query, parameters, userParameters, options, isVoiceSear
   }
 
   // Pull origin referrer from userParameters
-  if (originReferrer) {
+  if (originReferrer && typeof originReferrer === 'string') {
     queryParams.origin_referrer = originReferrer;
   }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -27,6 +27,7 @@ export interface UserParameters {
   userId?: string;
   segments?: string[];
   testCells?: Record<string, any>;
+  originReferrer?: string;
   userIp?: string;
   userAgent?: string;
 }


### PR DESCRIPTION
Add `originReferrer` support for **SABR** requests

**Summary**

- Add `originReferrer` to `UserParameters` for **Search**, **Autocomplete**, **Browse**, **Recommendations**, and **Quizzes** modules
- The value is passed as the `origin_referrer` query parameter in request URLs (matching the existing tracker behavior)

**Tests**

- Added tests for Search (`getSearchResults`, `getVoiceSearchResults`)
- Added tests for Autocomplete (`getAutocompleteResults`)
- Added tests for Browse (`getBrowseResults`)
- Added tests for Recommendations (`getRecommendations`)
- Added tests for Quizzes (`getQuizNextQuestion`, `getQuizResults`)