### PR TITLE
[NO-REF] Fix SDK compatibility with Bun when sending multipart form data

### DIFF
--- a/spec/src/modules/catalog/catalog-files.js
+++ b/spec/src/modules/catalog/catalog-files.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
-const { Duplex } = require('stream');
+const { Duplex, Readable } = require('stream');
 const ConstructorIO = require('../../../../test/constructorio'); // eslint-disable-line import/extensions
 const helpers = require('../../../mocha.helpers');
 
@@ -71,6 +71,28 @@ describe('ConstructorIO - Catalog', () => {
       .that.matches(/^multipart\/form-data; boundary=/);
     expect(requestOptions.headers).to.have.property('content-length')
       .that.matches(/^\d+$/);
+  });
+
+  it('should omit content length when stream length is unknown', async () => {
+    const fetchStub = sinon.stub().resolves({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const { catalog } = new ConstructorIO({
+      apiKey: 'test-api-key',
+      fetch: fetchStub,
+    });
+
+    await catalog.replaceCatalog({
+      items: Readable.from(['id\nitem-1']),
+      section: 'Products',
+    });
+
+    const [, requestOptions] = fetchStub.firstCall.args;
+
+    expect(requestOptions.headers).to.have.property('content-type')
+      .that.matches(/^multipart\/form-data; boundary=/);
+    expect(requestOptions.headers).to.not.have.property('content-length');
   });
 
   describe('Files', function catalogFiles() {

--- a/spec/src/modules/catalog/catalog-files.js
+++ b/spec/src/modules/catalog/catalog-files.js
@@ -50,51 +50,6 @@ describe('ConstructorIO - Catalog', () => {
     setTimeout(done, sendTimeout);
   });
 
-  it('should include multipart headers when uploading catalog files', async () => {
-    const fetchStub = sinon.stub().resolves({
-      ok: true,
-      json: () => Promise.resolve({}),
-    });
-    const { catalog } = new ConstructorIO({
-      apiKey: 'test-api-key',
-      fetch: fetchStub,
-    });
-
-    await catalog.replaceCatalog({
-      items: Buffer.from('id\nitem-1'),
-      section: 'Products',
-    });
-
-    const [, requestOptions] = fetchStub.firstCall.args;
-
-    expect(requestOptions.headers).to.have.property('content-type')
-      .that.matches(/^multipart\/form-data; boundary=/);
-    expect(requestOptions.headers).to.have.property('content-length')
-      .that.matches(/^\d+$/);
-  });
-
-  it('should omit content length when stream length is unknown', async () => {
-    const fetchStub = sinon.stub().resolves({
-      ok: true,
-      json: () => Promise.resolve({}),
-    });
-    const { catalog } = new ConstructorIO({
-      apiKey: 'test-api-key',
-      fetch: fetchStub,
-    });
-
-    await catalog.replaceCatalog({
-      items: Readable.from(['id\nitem-1']),
-      section: 'Products',
-    });
-
-    const [, requestOptions] = fetchStub.firstCall.args;
-
-    expect(requestOptions.headers).to.have.property('content-type')
-      .that.matches(/^multipart\/form-data; boundary=/);
-    expect(requestOptions.headers).to.not.have.property('content-length');
-  });
-
   describe('Files', function catalogFiles() {
     // Ensure Mocha doesn't time out waiting for operation to complete
     this.timeout(10000);
@@ -129,6 +84,57 @@ describe('ConstructorIO - Catalog', () => {
       variationsStream = createStreamFromBuffer(variationsBuffer);
       itemGroupsStream = createStreamFromBuffer(itemGroupsBuffer);
       tarArchiveStream = createStreamFromBuffer(tarArchiveBuffer);
+    });
+
+    it('should include multipart headers when uploading catalog files', async () => {
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        json: () => Promise.resolve({
+          task_id: 'test-task-id',
+          task_status_path: '/tasks/test-task-id',
+        }),
+      });
+      const { catalog } = new ConstructorIO({
+        apiKey: 'test-api-key',
+        fetch: fetchStub,
+      });
+
+      await catalog.replaceCatalog({
+        items: Buffer.from('id\nitem-1'),
+        section: 'Products',
+      });
+
+      const [, requestOptions] = fetchStub.firstCall.args;
+
+      expect(requestOptions.headers).to.have.property('content-type')
+        .that.matches(/^multipart\/form-data; boundary=/);
+      expect(requestOptions.headers).to.have.property('content-length')
+        .that.matches(/^\d+$/);
+    });
+
+    it('should omit content length when stream length is unknown', async () => {
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        json: () => Promise.resolve({
+          task_id: 'test-task-id',
+          task_status_path: '/tasks/test-task-id',
+        }),
+      });
+      const { catalog } = new ConstructorIO({
+        apiKey: 'test-api-key',
+        fetch: fetchStub,
+      });
+
+      await catalog.replaceCatalog({
+        items: Readable.from(['id\nitem-1']),
+        section: 'Products',
+      });
+
+      const [, requestOptions] = fetchStub.firstCall.args;
+
+      expect(requestOptions.headers).to.have.property('content-type')
+        .that.matches(/^multipart\/form-data; boundary=/);
+      expect(requestOptions.headers).to.not.have.property('content-length');
     });
 
     afterEach((done) => {
@@ -416,6 +422,32 @@ describe('ConstructorIO - Catalog', () => {
         force: true,
         notificationEmail: 'test@constructor.io',
       };
+
+      it('should include multipart headers when uploading tar archive', async () => {
+        const fetchStub = sinon.stub().resolves({
+          ok: true,
+          json: () => Promise.resolve({
+            task_id: 'test-task-id',
+            task_status_path: '/tasks/test-task-id',
+          }),
+        });
+        const { catalog } = new ConstructorIO({
+          apiKey: 'test-api-key',
+          fetch: fetchStub,
+        });
+
+        await catalog.replaceCatalogUsingTarArchive({
+          tarArchive: Buffer.from('fake-tar-data'),
+          section: 'Products',
+        });
+
+        const [, requestOptions] = fetchStub.firstCall.args;
+
+        expect(requestOptions.headers).to.have.property('content-type')
+          .that.matches(/^multipart\/form-data; boundary=/);
+        expect(requestOptions.headers).to.have.property('content-length')
+          .that.matches(/^\d+$/);
+      });
 
       it('Should replace a catalog of items, variations, and item groups using buffers', (done) => {
         const { catalog } = new ConstructorIO({

--- a/spec/src/modules/catalog/catalog-files.js
+++ b/spec/src/modules/catalog/catalog-files.js
@@ -50,6 +50,29 @@ describe('ConstructorIO - Catalog', () => {
     setTimeout(done, sendTimeout);
   });
 
+  it('should include multipart headers when uploading catalog files', async () => {
+    const fetchStub = sinon.stub().resolves({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const { catalog } = new ConstructorIO({
+      apiKey: 'test-api-key',
+      fetch: fetchStub,
+    });
+
+    await catalog.replaceCatalog({
+      items: Buffer.from('id\nitem-1'),
+      section: 'Products',
+    });
+
+    const [, requestOptions] = fetchStub.firstCall.args;
+
+    expect(requestOptions.headers).to.have.property('Content-Type')
+      .that.matches(/^multipart\/form-data; boundary=/);
+    expect(requestOptions.headers).to.have.property('Content-Length')
+      .that.matches(/^\d+$/);
+  });
+
   describe('Files', function catalogFiles() {
     // Ensure Mocha doesn't time out waiting for operation to complete
     this.timeout(10000);

--- a/spec/src/modules/catalog/catalog-files.js
+++ b/spec/src/modules/catalog/catalog-files.js
@@ -67,9 +67,9 @@ describe('ConstructorIO - Catalog', () => {
 
     const [, requestOptions] = fetchStub.firstCall.args;
 
-    expect(requestOptions.headers).to.have.property('Content-Type')
+    expect(requestOptions.headers).to.have.property('content-type')
       .that.matches(/^multipart\/form-data; boundary=/);
-    expect(requestOptions.headers).to.have.property('Content-Length')
+    expect(requestOptions.headers).to.have.property('content-length')
       .that.matches(/^\d+$/);
   });
 

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -182,9 +182,11 @@ function getMultipartHeaders(formData) {
   const headers = formData.getHeaders();
 
   if (formData.hasKnownLength()) {
-    headers['content-length'] = String(formData.getLengthSync());
-  } else {
-    // Let fetch use chunked transfer when form length cannot be determined.
+    try {
+      headers['content-length'] = String(formData.getLengthSync());
+    } catch {
+      // Let fetch use chunked transfer when form length cannot be determined synchronously.
+    }
   }
 
   return headers;

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -178,6 +178,18 @@ async function addTarArchiveToFormData(parameters, formData, operation, apiKey) 
   return formData;
 }
 
+function getMultipartHeaders(formData) {
+  const headers = formData.getHeaders();
+
+  try {
+    headers['Content-Length'] = String(formData.getLengthSync());
+  } catch {
+    // Let fetch use chunked transfer when form length cannot be determined.
+  }
+
+  return headers;
+}
+
 /**
  * Interface to catalog related API calls
  *
@@ -2595,7 +2607,10 @@ class Catalog {
       const response = await fetch(requestUrl, {
         method: 'PUT',
         body: formData,
-        headers: helpers.createAuthHeader(this.options),
+        headers: {
+          ...getMultipartHeaders(formData),
+          ...helpers.createAuthHeader(this.options),
+        },
         signal,
       });
 
@@ -2649,7 +2664,10 @@ class Catalog {
       const response = await fetch(requestUrl, {
         method: 'PATCH',
         body: formData,
-        headers: helpers.createAuthHeader(this.options),
+        headers: {
+          ...getMultipartHeaders(formData),
+          ...helpers.createAuthHeader(this.options),
+        },
         signal,
       });
 
@@ -2704,7 +2722,10 @@ class Catalog {
       const response = await fetch(requestUrl, {
         method: 'PATCH',
         body: formData,
-        headers: helpers.createAuthHeader(this.options),
+        headers: {
+          ...getMultipartHeaders(formData),
+          ...helpers.createAuthHeader(this.options),
+        },
         signal,
       });
 
@@ -2762,7 +2783,10 @@ class Catalog {
       const response = await fetch(requestUrl, {
         method: 'PUT',
         body: formDataWithTarArchive,
-        headers: helpers.createAuthHeader(this.options),
+        headers: {
+          ...getMultipartHeaders(formDataWithTarArchive),
+          ...helpers.createAuthHeader(this.options),
+        },
         signal,
       });
 
@@ -2822,7 +2846,10 @@ class Catalog {
       const response = await fetch(requestUrl, {
         method: 'PATCH',
         body: formDataWithTarArchive,
-        headers: helpers.createAuthHeader(this.options),
+        headers: {
+          ...getMultipartHeaders(formDataWithTarArchive),
+          ...helpers.createAuthHeader(this.options),
+        },
         signal,
       });
 
@@ -2882,7 +2909,10 @@ class Catalog {
       const response = await fetch(requestUrl, {
         method: 'PATCH',
         body: formDataWithTarArchive,
-        headers: helpers.createAuthHeader(this.options),
+        headers: {
+          ...getMultipartHeaders(formDataWithTarArchive),
+          ...helpers.createAuthHeader(this.options),
+        },
         signal,
       });
 

--- a/src/modules/catalog.js
+++ b/src/modules/catalog.js
@@ -181,9 +181,9 @@ async function addTarArchiveToFormData(parameters, formData, operation, apiKey) 
 function getMultipartHeaders(formData) {
   const headers = formData.getHeaders();
 
-  try {
-    headers['Content-Length'] = String(formData.getLengthSync());
-  } catch {
+  if (formData.hasKnownLength()) {
+    headers['content-length'] = String(formData.getLengthSync());
+  } else {
     // Let fetch use chunked transfer when form length cannot be determined.
   }
 


### PR DESCRIPTION
## Summary

- Add explicit multipart Content-Type and Content-Length headers to catalog uploads
- Preserve chunked transfer fallback when form length cannot be determined
- Add regression coverage for catalog upload headers

## Why

Bun's node-fetch compatibility shim does not infer headers for npm form-data bodies. Constructor API rejects those uploads because it cannot parse multipart fields. Node-fetch on Node infers these headers automatically.

When using Bun to upload files via SDK, this error is seen:

```
error: form-data should contain at least one of "items", "variations", "item_groups" file(s)
     status: 400,
 statusText: "BAD REQUEST",
        url: "https://ac.cnstrc.com/v1/catalog?section=Products&on_missing=IGNORE&format=csv&patch_delta=true&key=key_123",
    headers: Headers {
  "date": "Fri, 17 Jul 2026 01:28:33 GMT",
  "content-type": "application/json",
  "content-length": "105",
  "connection": "keep-alive",
  "age": "0",
  "x-ratelimit-limit": "201",
  "x-ratelimit-remaining": "200",
  "x-ratelimit-reset": "1784251711",
  "x-varnish": "372297",
},

      at patchCatalogUsingTarArchive (/Users/pedro.bini/Documents/repro/node_modules/@constructor-io/constructorio-node/src/modules/catalog.js:2893:53)

Bun v1.3.14 (macOS arm64)
```

## Testing

- CI test suite
- Lint hook passed with existing warning in `spec/src/modules/catalog/catalog-facet-configurations-v2.js:70`
- Local full suite not run per request