### PR TITLE
[CDX-501] Add support for refined filters as top level URL parameters in browse results

### DIFF
--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -565,6 +565,59 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should send refined filters supplied within the qs param as a top level url parameter', (done) => {
+      const qsParam = { refined_filters: { group_id: 'BrandXY' } };
+      const { browse } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseResults(filterName, filterValue, { qsParam }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(requestedUrlParams).to.have.property('refined_filters');
+        expect(requestedUrlParams.refined_filters).to.have.property('group_id').to.equal('BrandXY');
+        expect(requestedUrlParams).to.not.have.property('qs');
+        expect(res.request.refined_filters).to.deep.equal(qsParam.refined_filters);
+        done();
+      });
+    });
+
+    it('Should retain the remaining qs param values when sending refined filters as a top level url parameter', (done) => {
+      const qsParam = {
+        num_results_per_page: '10',
+        refined_filters: { group_id: 'BrandXY' },
+      };
+      const { browse } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseResults(filterName, filterValue, { qsParam }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(requestedUrlParams.refined_filters).to.have.property('group_id').to.equal('BrandXY');
+        expect(JSON.parse(requestedUrlParams.qs)).to.deep.equal({ num_results_per_page: '10' });
+        expect(res.request.num_results_per_page).to.equal(10);
+        expect(res.request.refined_filters).to.deep.equal(qsParam.refined_filters);
+        done();
+      });
+    });
+
+    it('Should not mutate the supplied qs param when sending refined filters as a top level url parameter', (done) => {
+      const qsParam = { refined_filters: { group_id: 'BrandXY' } };
+      const { browse } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      browse.getBrowseResults(filterName, filterValue, { qsParam }).then(() => {
+        expect(qsParam).to.deep.equal({ refined_filters: { group_id: 'BrandXY' } });
+        done();
+      });
+    });
+
     it('Should properly encode path parameters', (done) => {
       const specialCharacters = '+[]&';
       const filterNameSpecialCharacters = `name ${specialCharacters}`;

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -108,9 +108,17 @@ function createQueryParams(parameters, userParameters, options) {
       queryParams.pre_filter_expression = JSON.stringify(preFilterExpression);
     }
 
-    // Pull qs param from parameters
+    // Pull qs param from parameters - refined filters are sent as a top level parameter
     if (qsParam) {
-      queryParams.qs = JSON.stringify(qsParam);
+      const { refined_filters: refinedFilters, ...remainingQsParam } = qsParam;
+
+      if (refinedFilters) {
+        queryParams.refined_filters = refinedFilters;
+      }
+
+      if (Object.keys(remainingQsParam).length) {
+        queryParams.qs = JSON.stringify(remainingQsParam);
+      }
     }
   }
 


### PR DESCRIPTION
This pull request enhances how refined filters are handled in the `browse` module by sending them as top-level URL parameters instead of nesting them within the `qs` parameter. It also introduces comprehensive tests to ensure this behavior and to verify that the original input is not mutated.

**Refined filter handling improvements:**

* Updated `createQueryParams` in `src/modules/browse.js` to extract `refined_filters` from the `qsParam` object and send them as top-level parameters in the URL, while any remaining `qsParam` values are still sent under `qs`. This ensures proper API parameter structure and avoids unnecessary nesting.

**Testing enhancements:**

* Added tests in `spec/src/modules/browse.js` to verify:
  - `refined_filters` are sent as top-level parameters when supplied in `qsParam`.
  - Other `qsParam` values are retained and sent correctly under `qs` when `refined_filters` is present.
  - The original `qsParam` object is not mutated during processing.