### PR TITLE
[NO-REF] Preserve HTTP error details when the response body is not JSON

### DIFF
--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -145,22 +145,51 @@ describe('ConstructorIO - Utils - Helpers', () => {
           },
         };
 
-        try {
-          await throwHttpErrorFromResponse(new Error(), {
-            json: () => new Promise((resolve) => {
-              resolve({
-                message: errorMessage,
-              });
-            }),
-            ...responseData,
-          });
-        } catch (e) {
-          expect(e.message).to.equal(errorMessage);
-          expect(e.status).to.equal(responseData.status);
-          expect(e.statusText).to.equal(responseData.statusText);
-          expect(e.url).to.equal(responseData.url);
-          expect(e.headers).to.deep.equal(responseData.headers);
-        }
+        const error = await throwHttpErrorFromResponse(new Error(), {
+          text: () => Promise.resolve(JSON.stringify({ message: errorMessage })),
+          ...responseData,
+        }).catch((e) => e);
+
+        expect(error.message).to.equal(errorMessage);
+        expect(error.status).to.equal(responseData.status);
+        expect(error.statusText).to.equal(responseData.statusText);
+        expect(error.url).to.equal(responseData.url);
+        expect(error.headers).to.deep.equal(responseData.headers);
+      });
+
+      it('Should throw an error with the raw body when the response is not JSON', async () => {
+        const responseData = {
+          status: 429,
+          statusText: 'Too Many Requests',
+          url: 'https://constructor.io',
+          headers: {
+            'retry-after': '30',
+          },
+        };
+
+        const error = await throwHttpErrorFromResponse(new Error(), {
+          text: () => Promise.resolve('Too many requests'),
+          ...responseData,
+        }).catch((e) => e);
+
+        expect(error.message).to.equal('Too many requests');
+        expect(error.status).to.equal(responseData.status);
+        expect(error.statusText).to.equal(responseData.statusText);
+        expect(error.url).to.equal(responseData.url);
+        expect(error.headers).to.deep.equal(responseData.headers);
+      });
+
+      it('Should throw an error with a status fallback when the response body is empty', async () => {
+        const error = await throwHttpErrorFromResponse(new Error(), {
+          text: () => Promise.resolve(''),
+          status: 502,
+          statusText: 'Bad Gateway',
+          url: 'https://constructor.io',
+          headers: {},
+        }).catch((e) => e);
+
+        expect(error.message).to.equal('HTTP 502');
+        expect(error.status).to.equal(502);
       });
     });
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -48,15 +48,34 @@ const utils = {
     return snakeCasedObj;
   },
 
-  throwHttpErrorFromResponse: (error, response) => response.json().then((json) => {
-    error.message = json.message;
+  // Attach the details of a non-2XX response to an error and throw it
+  // - Error bodies are not always JSON: rate limit and gateway responses are
+  //   commonly plain text or HTML, so attempting to parse and falling back to
+  //   the raw body keeps the real status and message instead of surfacing a
+  //   SyntaxError from the parse itself
+  throwHttpErrorFromResponse: async (error, response) => {
+    let message = '';
+
+    try {
+      message = await response.text();
+
+      const parsed = JSON.parse(message);
+
+      if (parsed && typeof parsed.message === 'string') {
+        message = parsed.message;
+      }
+    } catch (e) {
+      // Body is either unreadable or not JSON - keep whatever text we have
+    }
+
+    error.message = message.trim() || `HTTP ${response.status}`;
     error.status = response.status;
     error.statusText = response.statusText;
     error.url = response.url;
     error.headers = response.headers;
 
     throw error;
-  }),
+  },
 
   isNil: (value) => value == null,
 


### PR DESCRIPTION
## Summary

- `throwHttpErrorFromResponse` reads the error body as text and attempts to parse it, instead of assuming JSON
- Falls back to the raw body text as `error.message`, and to `HTTP <status>` when the body is empty
- Adds coverage for a plain-text error body and an empty one

## Why

Every module routes its non-2XX responses through `helpers.throwHttpErrorFromResponse`, which called `response.json()` unconditionally. Error responses are not always JSON — rate limit and gateway responses are commonly plain text or HTML. For those, the parse rejects and the SDK surfaces the parse failure rather than the request failure:

```
SyntaxError: Unexpected token 'T', "Too many requests" is not valid JSON
  at Response.json (node_modules/node-fetch/src/body.js:149:15)
```

The `status`, `statusText`, `url` and `headers` go with it — the details the function exists to attach. A caller has no way to tell a rate limit from a bad gateway from a malformed payload.

`tracker.js` already handles non-JSON bodies this way when it emits error events, so this brings the request path in line with it.

## Behavior change

`error.message` is now always a string. Previously a JSON body without a `message` field produced `error.message === undefined`, which made `error.message.toLowerCase()` throw — there is a call site doing exactly that in `spec/src/modules/catalog/catalog-groups-v2.js:223`.

## Testing

- `npx mocha spec/src/utils/helpers.js` — 22 passing, including the three `throwHttpErrorFromResponse` cases (JSON body, plain-text body, empty body)
- `npm run lint` — clean, only the pre-existing `no-console` warning in `spec/src/modules/catalog/catalog-facet-configurations-v2.js:70`
- `npm run test:types` — passing
- Full suite not run locally: it requires catalog API credentials I don't have set up

## Note on CI

This makes the failure legible, it does not make the suite pass. `run-tests.yml` runs 991 tests that each make a real API call, in `mocha --parallel`, against a rate limit the run exceeds. 27 of the last 30 runs on this workflow failed, on every branch including Dependabot's, going back to April. With this change those runs report `429 / Too many requests` with the status attached instead of a `SyntaxError`, which is a prerequisite for fixing the suite but not a fix for it.

The remaining failures are `Timeout of 5000ms exceeded` in `before`/`beforeEach` hooks. Worth noting `--retries 3` does not apply to hook failures, so a single rate-limited hook takes out its whole `describe` block. Happy to open an issue with the details if that's useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)